### PR TITLE
feat: add `credat revoke` command

### DIFF
--- a/src/commands/revoke.test.ts
+++ b/src/commands/revoke.test.ts
@@ -1,0 +1,237 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createAgent, createStatusList, delegate, encodeStatusList } from "credat";
+import { describe, expect, it } from "vitest";
+import { collectLogs, useTestDir } from "../test-utils.js";
+import { credatDir, saveDelegation, saveOwner } from "../utils.js";
+
+/** Create a fake token with a status list entry in the payload. */
+function fakeTokenWithStatus(idx: number, uri: string): string {
+	const hdr = Buffer.from(JSON.stringify({ alg: "ES256", typ: "dc+sd-jwt" })).toString("base64url");
+	const payload = Buffer.from(
+		JSON.stringify({
+			iss: "did:web:owner.local",
+			sub: "did:web:agent.local",
+			status: { status_list: { idx, uri } },
+		}),
+	).toString("base64url");
+	return `${hdr}.${payload}.fake-sig`;
+}
+
+/** Create a fake token WITHOUT a status list entry. */
+function fakeTokenWithoutStatus(): string {
+	const hdr = Buffer.from(JSON.stringify({ alg: "ES256" })).toString("base64url");
+	const payload = Buffer.from(
+		JSON.stringify({ iss: "did:web:owner.local", sub: "did:web:agent.local" }),
+	).toString("base64url");
+	return `${hdr}.${payload}.fake-sig`;
+}
+
+/** Seed a status-list.json file in .credat/. */
+function seedStatusList(): void {
+	const dir = credatDir();
+	mkdirSync(dir, { recursive: true });
+	const list = createStatusList({
+		id: "default",
+		issuer: "did:web:owner.local",
+		url: "https://owner.local/status/1",
+	});
+	const file = {
+		id: list.id,
+		issuer: list.issuer,
+		url: "https://owner.local/status/1",
+		size: list.size,
+		encoded: encodeStatusList(list.bitstring),
+	};
+	writeFileSync(join(dir, "status-list.json"), JSON.stringify(file));
+}
+
+describe("revoke command — error paths", () => {
+	useTestDir("revoke-errors");
+
+	it("errors when no token and no delegation.json", async () => {
+		const { revokeCommand } = await import("./revoke.js");
+		expect(() => revokeCommand()).toThrow("No delegation found");
+	});
+
+	it("errors when token has no status list entry", async () => {
+		const { revokeCommand } = await import("./revoke.js");
+		expect(() =>
+			revokeCommand({ token: fakeTokenWithoutStatus() }),
+		).toThrow("no status list entry");
+	});
+
+	it("errors when --index is not a valid number", async () => {
+		const { revokeCommand } = await import("./revoke.js");
+		expect(() => revokeCommand({ index: "abc" })).toThrow(
+			"--index must be a non-negative integer",
+		);
+	});
+
+	it("errors when --index is negative", async () => {
+		const { revokeCommand } = await import("./revoke.js");
+		expect(() => revokeCommand({ index: "-1" })).toThrow(
+			"--index must be a non-negative integer",
+		);
+	});
+});
+
+describe("revoke command — with explicit --index", () => {
+	useTestDir("revoke-index");
+
+	it("revokes with --index and creates status list when owner exists", async () => {
+		const owner = await createAgent({ domain: "owner.local", algorithm: "ES256" });
+		saveOwner(owner);
+		seedStatusList();
+
+		const { revokeCommand } = await import("./revoke.js");
+		revokeCommand({ index: "42" });
+
+		const logs = collectLogs();
+		expect(logs).toContain("revoked");
+		expect(logs).toContain("42");
+
+		// Verify status list was saved
+		const slPath = join(credatDir(), "status-list.json");
+		expect(existsSync(slPath)).toBe(true);
+	});
+
+	it("reports already revoked on second revocation", async () => {
+		const owner = await createAgent({ domain: "owner.local", algorithm: "ES256" });
+		saveOwner(owner);
+		seedStatusList();
+
+		const { revokeCommand } = await import("./revoke.js");
+		revokeCommand({ index: "10" });
+
+		const logs1 = collectLogs();
+		expect(logs1).toContain("revoked");
+
+		// Second call
+		revokeCommand({ index: "10" });
+		const logs2 = collectLogs();
+		expect(logs2).toContain("already revoked");
+	});
+});
+
+describe("revoke command — from token", () => {
+	useTestDir("revoke-token");
+
+	it("extracts index from token and revokes", async () => {
+		const owner = await createAgent({ domain: "owner.local", algorithm: "ES256" });
+		saveOwner(owner);
+		seedStatusList();
+
+		const token = fakeTokenWithStatus(7, "https://owner.local/status/1");
+
+		const { revokeCommand } = await import("./revoke.js");
+		revokeCommand({ token });
+
+		const logs = collectLogs();
+		expect(logs).toContain("revoked");
+		expect(logs).toContain("7");
+	});
+});
+
+describe("revoke command — from delegation.json", () => {
+	useTestDir("revoke-delegation");
+
+	it("loads token from delegation.json and revokes", async () => {
+		const agent = await createAgent({ domain: "agent.local", algorithm: "ES256" });
+		const owner = await createAgent({ domain: "owner.local", algorithm: "ES256" });
+		saveOwner(owner);
+
+		const d = await delegate({
+			agent: agent.did,
+			owner: owner.did,
+			ownerKeyPair: owner.keyPair,
+			scopes: ["read"],
+			statusList: { url: "https://owner.local/status/1", index: 99 },
+		});
+		saveDelegation(d);
+		seedStatusList();
+
+		const { revokeCommand } = await import("./revoke.js");
+		revokeCommand();
+
+		const logs = collectLogs();
+		expect(logs).toContain("revoked");
+		expect(logs).toContain("99");
+	});
+});
+
+describe("revoke command — JSON output", () => {
+	useTestDir("revoke-json");
+
+	it("outputs JSON for successful revocation", async () => {
+		const owner = await createAgent({ domain: "owner.local", algorithm: "ES256" });
+		saveOwner(owner);
+		seedStatusList();
+
+		const { revokeCommand } = await import("./revoke.js");
+		revokeCommand({ index: "5", json: true });
+
+		const logs = collectLogs();
+		const jsonLine = logs.split("\n").find((l: string) => l.startsWith("{"));
+		expect(jsonLine).toBeDefined();
+
+		const parsed = JSON.parse(jsonLine!);
+		expect(parsed.revoked).toBe(true);
+		expect(parsed.index).toBe(5);
+		expect(parsed.alreadyRevoked).toBe(false);
+	});
+
+	it("outputs JSON for already-revoked", async () => {
+		const owner = await createAgent({ domain: "owner.local", algorithm: "ES256" });
+		saveOwner(owner);
+		seedStatusList();
+
+		const { revokeCommand } = await import("./revoke.js");
+		revokeCommand({ index: "5" });
+		revokeCommand({ index: "5", json: true });
+
+		const logs = collectLogs();
+		const jsonLines = logs.split("\n").filter((l: string) => l.startsWith("{"));
+		const last = JSON.parse(jsonLines[jsonLines.length - 1]!);
+		expect(last.revoked).toBe(true);
+		expect(last.alreadyRevoked).toBe(true);
+	});
+});
+
+describe("revoke command — custom status list path", () => {
+	useTestDir("revoke-custom-sl");
+
+	it("uses --status-list for custom path", async () => {
+		const owner = await createAgent({ domain: "owner.local", algorithm: "ES256" });
+		saveOwner(owner);
+
+		// Create status list at custom location
+		const list = createStatusList({
+			id: "custom",
+			issuer: owner.did,
+			url: "https://owner.local/status/custom",
+		});
+		const customPath = join(process.cwd(), "custom-sl.json");
+		writeFileSync(
+			customPath,
+			JSON.stringify({
+				id: list.id,
+				issuer: list.issuer,
+				url: "https://owner.local/status/custom",
+				size: list.size,
+				encoded: encodeStatusList(list.bitstring),
+			}),
+		);
+
+		const { revokeCommand } = await import("./revoke.js");
+		revokeCommand({ index: "3", statusList: customPath });
+
+		const logs = collectLogs();
+		expect(logs).toContain("revoked");
+		expect(logs).toContain("3");
+
+		// Verify it saved back to the custom path
+		const saved = JSON.parse(readFileSync(customPath, "utf-8"));
+		expect(saved.id).toBe("custom");
+	});
+});

--- a/src/commands/revoke.ts
+++ b/src/commands/revoke.ts
@@ -1,0 +1,210 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	createStatusList,
+	decodeStatusList,
+	encodeStatusList,
+	isRevoked,
+	type StatusListData,
+	setRevocationStatus,
+} from "credat";
+import pc from "picocolors";
+import {
+	credatDir,
+	delegationExists,
+	fail,
+	header,
+	label,
+	loadDelegationFile,
+	loadOwnerFile,
+	ownerExists,
+	success,
+} from "../utils.js";
+
+interface RevokeOptions {
+	token?: string;
+	statusList?: string;
+	index?: string;
+	json?: boolean;
+}
+
+interface StatusListFile {
+	id: string;
+	issuer: string;
+	url: string;
+	size: number;
+	encoded: string;
+}
+
+const STATUS_LIST_FILE = "status-list.json";
+
+function statusListPath(): string {
+	return join(credatDir(), STATUS_LIST_FILE);
+}
+
+function extractStatusEntry(
+	token: string,
+): { idx: number; uri: string } | null {
+	try {
+		const jwtPart = token.split("~")[0];
+		if (!jwtPart) return null;
+		const payloadRaw = jwtPart.split(".")[1];
+		if (!payloadRaw) return null;
+		const payload = JSON.parse(
+			Buffer.from(payloadRaw, "base64url").toString("utf-8"),
+		) as Record<string, unknown>;
+		const status = payload.status as
+			| { status_list?: { idx?: number; uri?: string } }
+			| undefined;
+		if (
+			status?.status_list &&
+			typeof status.status_list.idx === "number" &&
+			typeof status.status_list.uri === "string"
+		) {
+			return { idx: status.status_list.idx, uri: status.status_list.uri };
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+function loadStatusList(filePath: string): {
+	data: StatusListData;
+	file: StatusListFile;
+} {
+	if (!existsSync(filePath)) {
+		throw new Error(
+			`No status list found at ${filePath}. Run a delegation with --status-list first or provide --status-list path.`,
+		);
+	}
+	const file = JSON.parse(readFileSync(filePath, "utf-8")) as StatusListFile;
+	const bitstring = decodeStatusList(file.encoded);
+	return {
+		data: {
+			bitstring,
+			id: file.id,
+			issuer: file.issuer,
+			size: file.size,
+		},
+		file,
+	};
+}
+
+function saveStatusList(filePath: string, data: StatusListData): void {
+	const file: StatusListFile = {
+		id: data.id,
+		issuer: data.issuer,
+		url: filePath,
+		size: data.size,
+		encoded: encodeStatusList(data.bitstring),
+	};
+	writeFileSync(filePath, JSON.stringify(file, null, "\t"));
+}
+
+function createDefaultStatusList(): StatusListData {
+	if (!ownerExists()) {
+		throw new Error(`No owner found. Run ${pc.bold("credat delegate")} first.`);
+	}
+	const owner = loadOwnerFile();
+	return createStatusList({
+		id: "default",
+		issuer: owner.did,
+		url: `${owner.did}/status/1`,
+	});
+}
+
+function resolveToken(options: RevokeOptions): string {
+	if (options.token) return options.token;
+
+	if (delegationExists()) {
+		return loadDelegationFile().token;
+	}
+
+	throw new Error(
+		`No delegation found. Use ${pc.bold("--token <token>")} or run ${pc.bold("credat delegate")} first.`,
+	);
+}
+
+export function revokeCommand(options: RevokeOptions = {}): void {
+	// 1. Resolve the status list index
+	let index: number;
+	let statusListFilePath: string;
+
+	if (options.index !== undefined) {
+		// Explicit --index provided
+		const parsed = Number(options.index);
+		if (!Number.isInteger(parsed) || parsed < 0) {
+			throw new Error("--index must be a non-negative integer");
+		}
+		index = parsed;
+		statusListFilePath = options.statusList ?? statusListPath();
+	} else {
+		// Extract from token
+		const token = resolveToken(options);
+		const entry = extractStatusEntry(token);
+		if (!entry) {
+			throw new Error(
+				"Delegation token has no status list entry. " +
+					"Re-issue the delegation with a status list, or use --index to specify manually.",
+			);
+		}
+		index = entry.idx;
+		statusListFilePath = options.statusList ?? statusListPath();
+	}
+
+	// 2. Load or create the status list
+	let listData: StatusListData;
+	if (existsSync(statusListFilePath)) {
+		const loaded = loadStatusList(statusListFilePath);
+		listData = loaded.data;
+	} else {
+		listData = createDefaultStatusList();
+	}
+
+	// 3. Check if already revoked
+	if (isRevoked(listData, index)) {
+		if (options.json) {
+			console.log(
+				JSON.stringify({
+					revoked: true,
+					index,
+					statusList: statusListFilePath,
+					alreadyRevoked: true,
+				}),
+			);
+			return;
+		}
+		header("Revocation");
+		fail(
+			`Index ${pc.bold(String(index))} is already revoked in the status list`,
+		);
+		console.log();
+		return;
+	}
+
+	// 4. Revoke
+	setRevocationStatus(listData, index, true);
+
+	// 5. Save
+	saveStatusList(statusListFilePath, listData);
+
+	// 6. Output
+	if (options.json) {
+		console.log(
+			JSON.stringify({
+				revoked: true,
+				index,
+				statusList: statusListFilePath,
+				alreadyRevoked: false,
+			}),
+		);
+		return;
+	}
+
+	header("Revocation");
+	success(`Delegation at index ${pc.bold(String(index))} revoked`);
+	label("Status List", pc.dim(statusListFilePath));
+	label("Index", String(index));
+	console.log();
+}

--- a/src/commands/revoke.ts
+++ b/src/commands/revoke.ts
@@ -91,11 +91,15 @@ function loadStatusList(filePath: string): {
 	};
 }
 
-function saveStatusList(filePath: string, data: StatusListData): void {
+function saveStatusList(
+	filePath: string,
+	data: StatusListData,
+	url: string,
+): void {
 	const file: StatusListFile = {
 		id: data.id,
 		issuer: data.issuer,
-		url: filePath,
+		url,
 		size: data.size,
 		encoded: encodeStatusList(data.bitstring),
 	};
@@ -155,11 +159,14 @@ export function revokeCommand(options: RevokeOptions = {}): void {
 
 	// 2. Load or create the status list
 	let listData: StatusListData;
+	let listUrl: string;
 	if (existsSync(statusListFilePath)) {
 		const loaded = loadStatusList(statusListFilePath);
 		listData = loaded.data;
+		listUrl = loaded.file.url;
 	} else {
 		listData = createDefaultStatusList();
+		listUrl = `${listData.issuer}/status/1`;
 	}
 
 	// 3. Check if already revoked
@@ -187,7 +194,7 @@ export function revokeCommand(options: RevokeOptions = {}): void {
 	setRevocationStatus(listData, index, true);
 
 	// 5. Save
-	saveStatusList(statusListFilePath, listData);
+	saveStatusList(statusListFilePath, listData, listUrl);
 
 	// 6. Output
 	if (options.json) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { delegateCommand } from "./commands/delegate.js";
 import { demoCommand } from "./commands/demo.js";
 import { initCommand } from "./commands/init.js";
 import { inspectCommand } from "./commands/inspect.js";
+import { revokeCommand } from "./commands/revoke.js";
 import { statusCommand } from "./commands/status.js";
 import { verifyCommand } from "./commands/verify.js";
 
@@ -75,6 +76,24 @@ program
 	.action(async (token, options) => {
 		await inspectCommand(token, {
 			file: options.file,
+			json: program.opts().json,
+		});
+	});
+
+program
+	.command("revoke")
+	.description("Revoke a delegation credential via status list")
+	.option("-t, --token <token>", "Delegation token to revoke")
+	.option(
+		"-s, --status-list <path>",
+		"Path to status list file (default: .credat/status-list.json)",
+	)
+	.option("-i, --index <number>", "Status list index to revoke")
+	.action((options) => {
+		revokeCommand({
+			token: options.token,
+			statusList: options.statusList,
+			index: options.index,
 			json: program.opts().json,
 		});
 	});

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,8 +89,8 @@ program
 		"Path to status list file (default: .credat/status-list.json)",
 	)
 	.option("-i, --index <number>", "Status list index to revoke")
-	.action((options) => {
-		revokeCommand({
+	.action(async (options) => {
+		await revokeCommand({
 			token: options.token,
 			statusList: options.statusList,
 			index: options.index,


### PR DESCRIPTION
## Summary
- Adds `credat revoke` command to revoke delegation credentials via the SDK's status list API
- Supports multiple token sources: `--token <token>`, fallback to `.credat/delegation.json`
- Extracts `status.status_list.{idx, uri}` from token payload, or accepts explicit `--index`
- Loads/creates `.credat/status-list.json` (or `--status-list <path>` for custom location)
- Detects and reports already-revoked delegations
- Pretty + `--json` output

## Test plan
- [x] 11 new tests (71 total, all passing)
- [x] Error paths: no token, no status entry, invalid index, negative index
- [x] Explicit `--index` revocation with status list creation
- [x] Already-revoked detection (second call reports it)
- [x] Token-based revocation (extracts index from payload)
- [x] Delegation.json fallback with real SDK `delegate()` token
- [x] JSON output for success and already-revoked
- [x] Custom `--status-list` path
- [x] Lint, typecheck, build all pass

Closes #2