### PR TITLE
feat: add `credat audit`, `credat renew`, and E2E test suite

### DIFF
--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -1,0 +1,336 @@
+import { createAgent, delegate } from "credat";
+import { describe, expect, it } from "vitest";
+import { collectLogs, useTestDir } from "../test-utils.js";
+import { saveDelegation, saveOwner } from "../utils.js";
+
+/** Build a fake token with given payload and optional disclosures. */
+function fakeToken(
+	payload: Record<string, unknown>,
+	disclosures: unknown[][] = [],
+): string {
+	const hdr = Buffer.from(
+		JSON.stringify({ alg: "ES256", typ: "dc+sd-jwt" }),
+	).toString("base64url");
+	const pld = Buffer.from(JSON.stringify(payload)).toString("base64url");
+	const sig = "fake-sig";
+	const jwt = `${hdr}.${pld}.${sig}`;
+	if (disclosures.length === 0) return jwt;
+	const encoded = disclosures
+		.map((d) => Buffer.from(JSON.stringify(d)).toString("base64url"))
+		.join("~");
+	return `${jwt}~${encoded}~`;
+}
+
+describe("audit command — error paths", () => {
+	useTestDir("audit-errors");
+
+	it("errors when no token and no delegation.json", async () => {
+		const { auditCommand } = await import("./audit.js");
+		expect(() => auditCommand(undefined)).toThrow("No token provided");
+	});
+});
+
+describe("audit command — expiration checks", () => {
+	useTestDir("audit-expiry");
+
+	it("flags expired token", async () => {
+		const pastExp = Math.floor(Date.now() / 1000) - 86400;
+		const token = fakeToken(
+			{ iss: "did:web:o", sub: "did:web:a", exp: pastExp },
+			[["s", "scopes", ["read"]]],
+		);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(token, { json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		const expFinding = parsed.findings.find(
+			(f: { rule: string }) => f.rule === "expiration",
+		);
+		expect(expFinding.level).toBe("fail");
+		expect(expFinding.message).toContain("expired");
+	});
+
+	it("warns on far-future expiry (>365 days)", async () => {
+		const farExp = Math.floor(Date.now() / 1000) + 86400 * 500;
+		const token = fakeToken(
+			{ iss: "did:web:o", sub: "did:web:a", exp: farExp },
+			[["s", "scopes", ["read"]]],
+		);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(token, { json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		const expFinding = parsed.findings.find(
+			(f: { rule: string }) => f.rule === "expiration",
+		);
+		expect(expFinding.level).toBe("warn");
+		expect(expFinding.message).toContain("shorter-lived");
+	});
+
+	it("passes on reasonable expiry (<365 days)", async () => {
+		const okExp = Math.floor(Date.now() / 1000) + 86400 * 30;
+		const token = fakeToken(
+			{ iss: "did:web:o", sub: "did:web:a", exp: okExp },
+			[["s", "scopes", ["read"]]],
+		);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(token, { json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		const expFinding = parsed.findings.find(
+			(f: { rule: string }) => f.rule === "expiration",
+		);
+		expect(expFinding.level).toBe("pass");
+	});
+
+	it("fails when no expiration at all", async () => {
+		const token = fakeToken({ iss: "did:web:o", sub: "did:web:a" }, [
+			["s", "scopes", ["read"]],
+		]);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(token, { json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		const expFinding = parsed.findings.find(
+			(f: { rule: string }) => f.rule === "expiration",
+		);
+		expect(expFinding.level).toBe("fail");
+		expect(expFinding.message).toContain("No expiration");
+	});
+
+	it("handles validUntil (ISO string) instead of exp", async () => {
+		const token = fakeToken(
+			{
+				iss: "did:web:o",
+				sub: "did:web:a",
+				validUntil: "2099-12-31T23:59:59Z",
+			},
+			[["s", "scopes", ["read"]]],
+		);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(token, { json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		const expFinding = parsed.findings.find(
+			(f: { rule: string }) => f.rule === "expiration",
+		);
+		// Far future → warn
+		expect(expFinding.level).toBe("warn");
+	});
+});
+
+describe("audit command — scope checks", () => {
+	useTestDir("audit-scopes");
+
+	it("warns on broad wildcard scopes", async () => {
+		const token = fakeToken(
+			{ iss: "did:web:o", sub: "did:web:a", exp: Math.floor(Date.now() / 1000) + 86400 },
+			[["s", "scopes", ["admin:*", "payments:read"]]],
+		);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(token, { json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		const scopeFinding = parsed.findings.find(
+			(f: { rule: string }) => f.rule === "scopes",
+		);
+		expect(scopeFinding.level).toBe("warn");
+		expect(scopeFinding.message).toContain("admin:*");
+	});
+
+	it("passes on narrow, focused scopes", async () => {
+		const token = fakeToken(
+			{ iss: "did:web:o", sub: "did:web:a", exp: Math.floor(Date.now() / 1000) + 86400 },
+			[["s", "scopes", ["payments:read", "invoices:create"]]],
+		);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(token, { json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		const scopeFinding = parsed.findings.find(
+			(f: { rule: string }) => f.rule === "scopes",
+		);
+		expect(scopeFinding.level).toBe("pass");
+	});
+});
+
+describe("audit command — constraint checks", () => {
+	useTestDir("audit-constraints");
+
+	it("passes when maxTransactionValue is set", async () => {
+		const token = fakeToken(
+			{ iss: "did:web:o", sub: "did:web:a", exp: Math.floor(Date.now() / 1000) + 86400 },
+			[
+				["s", "scopes", ["read"]],
+				["c", "constraints", { maxTransactionValue: 5000 }],
+			],
+		);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(token, { json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		const cFinding = parsed.findings.find(
+			(f: { rule: string }) => f.rule === "constraints.maxValue",
+		);
+		expect(cFinding.level).toBe("pass");
+	});
+
+	it("warns when no constraints at all", async () => {
+		const token = fakeToken(
+			{ iss: "did:web:o", sub: "did:web:a", exp: Math.floor(Date.now() / 1000) + 86400 },
+			[["s", "scopes", ["read"]]],
+		);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(token, { json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		const cFinding = parsed.findings.find(
+			(f: { rule: string }) => f.rule === "constraints",
+		);
+		expect(cFinding.level).toBe("warn");
+	});
+});
+
+describe("audit command — revocation checks", () => {
+	useTestDir("audit-revocation");
+
+	it("fails when no revocation endpoint", async () => {
+		const token = fakeToken(
+			{ iss: "did:web:o", sub: "did:web:a", exp: Math.floor(Date.now() / 1000) + 86400 },
+			[["s", "scopes", ["read"]]],
+		);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(token, { json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		const rFinding = parsed.findings.find(
+			(f: { rule: string }) => f.rule === "revocation",
+		);
+		expect(rFinding.level).toBe("fail");
+	});
+
+	it("passes when status list is configured", async () => {
+		const token = fakeToken(
+			{
+				iss: "did:web:o",
+				sub: "did:web:a",
+				exp: Math.floor(Date.now() / 1000) + 86400,
+				status: { status_list: { idx: 0, uri: "https://example.com/status" } },
+			},
+			[["s", "scopes", ["read"]]],
+		);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(token, { json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		const rFinding = parsed.findings.find(
+			(f: { rule: string }) => f.rule === "revocation",
+		);
+		expect(rFinding.level).toBe("pass");
+	});
+});
+
+describe("audit command — issuer/subject checks", () => {
+	useTestDir("audit-identity");
+
+	it("fails when no issuer", async () => {
+		const token = fakeToken(
+			{ sub: "did:web:a", exp: Math.floor(Date.now() / 1000) + 86400 },
+			[["s", "scopes", ["read"]]],
+		);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(token, { json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		expect(parsed.findings.some((f: { rule: string }) => f.rule === "issuer")).toBe(true);
+	});
+});
+
+describe("audit command — pretty output", () => {
+	useTestDir("audit-pretty");
+
+	it("shows colored output with icons", async () => {
+		const token = fakeToken(
+			{ iss: "did:web:o", sub: "did:web:a", exp: Math.floor(Date.now() / 1000) + 86400 },
+			[["s", "scopes", ["read"]]],
+		);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(token);
+
+		const logs = collectLogs();
+		expect(logs).toContain("Security Audit");
+		expect(logs).toContain("passed");
+	});
+});
+
+describe("audit command — fallback to delegation.json", () => {
+	useTestDir("audit-fallback");
+
+	it("loads token from delegation.json when no arg", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		const owner = await createAgent({ domain: "o.local", algorithm: "ES256" });
+		saveOwner(owner);
+
+		const d = await delegate({
+			agent: agent.did,
+			owner: owner.did,
+			ownerKeyPair: owner.keyPair,
+			scopes: ["read"],
+		});
+		saveDelegation(d);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(undefined, { json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		expect(parsed.findings.length).toBeGreaterThan(0);
+		expect(parsed.summary).toBeDefined();
+	});
+});
+
+describe("audit command — summary counts", () => {
+	useTestDir("audit-summary");
+
+	it("JSON summary has correct counts", async () => {
+		// Token with: good expiry, narrow scopes, no constraints, no revocation
+		const token = fakeToken(
+			{ iss: "did:web:o", sub: "did:web:a", exp: Math.floor(Date.now() / 1000) + 86400 * 30 },
+			[["s", "scopes", ["read"]]],
+		);
+
+		const { auditCommand } = await import("./audit.js");
+		auditCommand(token, { json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		expect(parsed.summary.pass + parsed.summary.warn + parsed.summary.fail).toBe(
+			parsed.findings.length,
+		);
+	});
+});

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,0 +1,298 @@
+import pc from "picocolors";
+import { delegationExists, header, loadDelegationFile } from "../utils.js";
+
+interface AuditOptions {
+	json?: boolean;
+}
+
+interface AuditFinding {
+	level: "pass" | "warn" | "fail";
+	rule: string;
+	message: string;
+}
+
+interface DecodedPayload {
+	iss?: string;
+	sub?: string;
+	exp?: number;
+	nbf?: number;
+	iat?: number;
+	agent?: string;
+	owner?: string;
+	status?: { status_list?: { idx?: number; uri?: string } };
+	validUntil?: string;
+	validFrom?: string;
+	[key: string]: unknown;
+}
+
+interface DecodedDisclosure {
+	name: string;
+	value: unknown;
+}
+
+function decodeToken(token: string): {
+	payload: DecodedPayload;
+	disclosures: DecodedDisclosure[];
+} {
+	const parts = token.split("~");
+	const jwtPart = parts[0];
+	if (!jwtPart) throw new Error("Token is empty");
+
+	const payloadRaw = jwtPart.split(".")[1];
+	if (!payloadRaw) throw new Error("Malformed token: no payload segment");
+
+	const payload = JSON.parse(
+		Buffer.from(payloadRaw, "base64url").toString("utf-8"),
+	) as DecodedPayload;
+
+	const disclosures: DecodedDisclosure[] = [];
+	for (let i = 1; i < parts.length; i++) {
+		const seg = parts[i];
+		if (!seg) continue;
+		try {
+			const decoded = JSON.parse(
+				Buffer.from(seg, "base64url").toString("utf-8"),
+			) as unknown[];
+			if (Array.isArray(decoded) && decoded.length >= 3) {
+				disclosures.push({ name: String(decoded[1]), value: decoded[2] });
+			}
+		} catch {
+			// skip malformed disclosures
+		}
+	}
+
+	return { payload, disclosures };
+}
+
+function findDisclosure(
+	disclosures: DecodedDisclosure[],
+	name: string,
+): unknown | undefined {
+	return disclosures.find((d) => d.name === name)?.value;
+}
+
+function auditToken(token: string): AuditFinding[] {
+	const findings: AuditFinding[] = [];
+	const { payload, disclosures } = decodeToken(token);
+
+	// 1. Expiration check
+	const now = Math.floor(Date.now() / 1000);
+	if (payload.exp) {
+		if (now >= payload.exp) {
+			findings.push({
+				level: "fail",
+				rule: "expiration",
+				message: `Token expired on ${new Date(payload.exp * 1000).toISOString()}`,
+			});
+		} else {
+			const daysLeft = Math.floor((payload.exp - now) / 86400);
+			if (daysLeft > 365) {
+				findings.push({
+					level: "warn",
+					rule: "expiration",
+					message: `Expires in ${daysLeft} days — consider shorter-lived tokens`,
+				});
+			} else {
+				findings.push({
+					level: "pass",
+					rule: "expiration",
+					message: `Expires in ${daysLeft} days`,
+				});
+			}
+		}
+	} else if (payload.validUntil) {
+		const expiry = new Date(payload.validUntil);
+		if (expiry < new Date()) {
+			findings.push({
+				level: "fail",
+				rule: "expiration",
+				message: `Token expired on ${payload.validUntil}`,
+			});
+		} else {
+			const daysLeft = Math.floor((expiry.getTime() - Date.now()) / 86_400_000);
+			if (daysLeft > 365) {
+				findings.push({
+					level: "warn",
+					rule: "expiration",
+					message: `Expires in ${daysLeft} days — consider shorter-lived tokens`,
+				});
+			} else {
+				findings.push({
+					level: "pass",
+					rule: "expiration",
+					message: `Expires in ${daysLeft} days`,
+				});
+			}
+		}
+	} else {
+		findings.push({
+			level: "fail",
+			rule: "expiration",
+			message: "No expiration set — tokens should always have an expiry",
+		});
+	}
+
+	// 2. Scope breadth check
+	const scopes = findDisclosure(disclosures, "scopes") as string[] | undefined;
+	if (scopes && Array.isArray(scopes)) {
+		const broad = scopes.filter(
+			(s) => s.endsWith(":*") || s === "*" || s === "admin",
+		);
+		if (broad.length > 0) {
+			findings.push({
+				level: "warn",
+				rule: "scopes",
+				message: `Broad scopes detected: ${broad.join(", ")} — consider narrowing`,
+			});
+		} else if (scopes.length > 10) {
+			findings.push({
+				level: "warn",
+				rule: "scopes",
+				message: `${scopes.length} scopes — consider grouping into fewer, focused scopes`,
+			});
+		} else {
+			findings.push({
+				level: "pass",
+				rule: "scopes",
+				message: `${scopes.length} scope${scopes.length === 1 ? "" : "s"} defined`,
+			});
+		}
+	} else {
+		findings.push({
+			level: "warn",
+			rule: "scopes",
+			message: "No scopes found in disclosures",
+		});
+	}
+
+	// 3. Constraint check
+	const constraints = findDisclosure(disclosures, "constraints") as
+		| Record<string, unknown>
+		| undefined;
+	if (constraints && typeof constraints === "object") {
+		if (constraints.maxTransactionValue !== undefined) {
+			findings.push({
+				level: "pass",
+				rule: "constraints.maxValue",
+				message: `Max transaction value: ${constraints.maxTransactionValue}`,
+			});
+		} else {
+			findings.push({
+				level: "warn",
+				rule: "constraints.maxValue",
+				message: "No maxTransactionValue constraint set",
+			});
+		}
+	} else {
+		findings.push({
+			level: "warn",
+			rule: "constraints",
+			message: "No constraints set — consider adding limits",
+		});
+	}
+
+	// 4. Revocation endpoint check
+	if (payload.status?.status_list?.uri) {
+		findings.push({
+			level: "pass",
+			rule: "revocation",
+			message: `Status list configured: ${payload.status.status_list.uri}`,
+		});
+	} else {
+		findings.push({
+			level: "fail",
+			rule: "revocation",
+			message: "No revocation endpoint configured",
+		});
+	}
+
+	// 5. Not-before check
+	if (payload.nbf) {
+		if (now < payload.nbf) {
+			findings.push({
+				level: "warn",
+				rule: "notBefore",
+				message: `Token not yet valid — activates ${new Date(payload.nbf * 1000).toISOString()}`,
+			});
+		} else {
+			findings.push({
+				level: "pass",
+				rule: "notBefore",
+				message: "Not-before constraint present and active",
+			});
+		}
+	}
+
+	// 6. Issuer/subject presence
+	if (!payload.iss) {
+		findings.push({
+			level: "fail",
+			rule: "issuer",
+			message: "No issuer (iss) claim found",
+		});
+	}
+	if (!payload.sub && !payload.agent) {
+		findings.push({
+			level: "fail",
+			rule: "subject",
+			message: "No subject (sub/agent) claim found",
+		});
+	}
+
+	return findings;
+}
+
+const ICONS: Record<AuditFinding["level"], string> = {
+	pass: pc.green("✓"),
+	warn: pc.yellow("⚠"),
+	fail: pc.red("✗"),
+};
+
+export function auditCommand(
+	token: string | undefined,
+	options: AuditOptions = {},
+): void {
+	if (!token) {
+		if (delegationExists()) {
+			token = loadDelegationFile().token;
+		} else {
+			throw new Error(
+				"No token provided. Usage: credat audit <token> or run credat delegate first.",
+			);
+		}
+	}
+
+	const findings = auditToken(token);
+
+	if (options.json) {
+		const passes = findings.filter((f) => f.level === "pass").length;
+		const warns = findings.filter((f) => f.level === "warn").length;
+		const fails = findings.filter((f) => f.level === "fail").length;
+		console.log(
+			JSON.stringify({
+				findings,
+				summary: { pass: passes, warn: warns, fail: fails },
+			}),
+		);
+		return;
+	}
+
+	header("Security Audit");
+
+	for (const f of findings) {
+		console.log(`  ${ICONS[f.level]} ${f.message}`);
+	}
+
+	console.log();
+	const passes = findings.filter((f) => f.level === "pass").length;
+	const warns = findings.filter((f) => f.level === "warn").length;
+	const fails = findings.filter((f) => f.level === "fail").length;
+
+	const parts: string[] = [];
+	if (passes > 0) parts.push(pc.green(`${passes} passed`));
+	if (warns > 0) parts.push(pc.yellow(`${warns} warnings`));
+	if (fails > 0) parts.push(pc.red(`${fails} issues`));
+
+	console.log(`  ${parts.join(pc.dim(" · "))}`);
+	console.log();
+}

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -41,9 +41,14 @@ function decodeToken(token: string): {
 	const payloadRaw = jwtPart.split(".")[1];
 	if (!payloadRaw) throw new Error("Malformed token: no payload segment");
 
-	const payload = JSON.parse(
-		Buffer.from(payloadRaw, "base64url").toString("utf-8"),
-	) as DecodedPayload;
+	let payload: DecodedPayload;
+	try {
+		payload = JSON.parse(
+			Buffer.from(payloadRaw, "base64url").toString("utf-8"),
+		) as DecodedPayload;
+	} catch {
+		throw new Error("Malformed token: invalid payload encoding or JSON");
+	}
 
 	const disclosures: DecodedDisclosure[] = [];
 	for (let i = 1; i < parts.length; i++) {
@@ -102,7 +107,13 @@ function auditToken(token: string): AuditFinding[] {
 		}
 	} else if (payload.validUntil) {
 		const expiry = new Date(payload.validUntil);
-		if (expiry < new Date()) {
+		if (Number.isNaN(expiry.getTime())) {
+			findings.push({
+				level: "fail",
+				rule: "expiration",
+				message: `Invalid validUntil format: ${payload.validUntil}`,
+			});
+		} else if (expiry < new Date()) {
 			findings.push({
 				level: "fail",
 				rule: "expiration",
@@ -136,7 +147,9 @@ function auditToken(token: string): AuditFinding[] {
 	const scopes = findDisclosure(disclosures, "scopes") as string[] | undefined;
 	if (scopes && Array.isArray(scopes)) {
 		const broad = scopes.filter(
-			(s) => s.endsWith(":*") || s === "*" || s === "admin",
+			(s) =>
+				typeof s === "string" &&
+				(s.endsWith(":*") || s === "*" || s === "admin"),
 		);
 		if (broad.length > 0) {
 			findings.push({

--- a/src/commands/renew.test.ts
+++ b/src/commands/renew.test.ts
@@ -1,0 +1,207 @@
+import { createAgent, delegate } from "credat";
+import { describe, expect, it } from "vitest";
+import { collectLogs, useTestDir } from "../test-utils.js";
+import {
+	loadDelegationFile,
+	saveAgent,
+	saveDelegation,
+	saveOwner,
+} from "../utils.js";
+
+describe("renew command — error paths", () => {
+	useTestDir("renew-errors");
+
+	it("errors when no delegation exists", async () => {
+		const { renewCommand } = await import("./renew.js");
+		await expect(renewCommand({ until: "2099-12-31T00:00:00Z" })).rejects.toThrow(
+			"No delegation found",
+		);
+	});
+
+	it("errors when no owner exists", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		const owner = await createAgent({ domain: "o.local", algorithm: "ES256" });
+		saveAgent(agent);
+
+		const d = await delegate({
+			agent: agent.did,
+			owner: owner.did,
+			ownerKeyPair: owner.keyPair,
+			scopes: ["read"],
+		});
+		saveDelegation(d);
+		// Don't save owner — intentionally missing
+
+		const { renewCommand } = await import("./renew.js");
+		await expect(renewCommand({ until: "2099-12-31T00:00:00Z" })).rejects.toThrow(
+			"No owner found",
+		);
+	});
+
+	it("errors on invalid date format", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		const owner = await createAgent({ domain: "o.local", algorithm: "ES256" });
+		saveAgent(agent);
+		saveOwner(owner);
+
+		const d = await delegate({
+			agent: agent.did,
+			owner: owner.did,
+			ownerKeyPair: owner.keyPair,
+			scopes: ["read"],
+		});
+		saveDelegation(d);
+
+		const { renewCommand } = await import("./renew.js");
+		await expect(renewCommand({ until: "not-a-date" })).rejects.toThrow(
+			"valid ISO 8601",
+		);
+	});
+
+	it("errors when date is in the past", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		const owner = await createAgent({ domain: "o.local", algorithm: "ES256" });
+		saveAgent(agent);
+		saveOwner(owner);
+
+		const d = await delegate({
+			agent: agent.did,
+			owner: owner.did,
+			ownerKeyPair: owner.keyPair,
+			scopes: ["read"],
+		});
+		saveDelegation(d);
+
+		const { renewCommand } = await import("./renew.js");
+		await expect(renewCommand({ until: "2020-01-01T00:00:00Z" })).rejects.toThrow(
+			"must be in the future",
+		);
+	});
+});
+
+describe("renew command — happy path", () => {
+	useTestDir("renew-happy");
+
+	it("renews delegation preserving scopes and constraints", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		const owner = await createAgent({ domain: "o.local", algorithm: "ES256" });
+		saveAgent(agent);
+		saveOwner(owner);
+
+		const original = await delegate({
+			agent: agent.did,
+			owner: owner.did,
+			ownerKeyPair: owner.keyPair,
+			scopes: ["payments:read", "invoices:create"],
+			constraints: { maxTransactionValue: 5000 },
+			validUntil: "2025-01-01T00:00:00Z",
+		});
+		saveDelegation(original);
+
+		const { renewCommand } = await import("./renew.js");
+		await renewCommand({ until: "2099-12-31T23:59:59Z" });
+
+		const renewed = loadDelegationFile();
+		// Token changed
+		expect(renewed.token).not.toBe(original.token);
+		// Scopes preserved
+		expect(renewed.claims.scopes).toEqual([
+			"payments:read",
+			"invoices:create",
+		]);
+		// Constraints preserved
+		expect(renewed.claims.constraints?.maxTransactionValue).toBe(5000);
+	});
+
+	it("pretty output shows renewal details", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		const owner = await createAgent({ domain: "o.local", algorithm: "ES256" });
+		saveAgent(agent);
+		saveOwner(owner);
+
+		const d = await delegate({
+			agent: agent.did,
+			owner: owner.did,
+			ownerKeyPair: owner.keyPair,
+			scopes: ["read"],
+		});
+		saveDelegation(d);
+
+		const { renewCommand } = await import("./renew.js");
+		await renewCommand({ until: "2099-06-15T00:00:00Z" });
+
+		const logs = collectLogs();
+		expect(logs).toContain("Delegation Renewed");
+		expect(logs).toContain(agent.did);
+		expect(logs).toContain(owner.did);
+		expect(logs).toContain("2099-06-15T00:00:00Z");
+		expect(logs).toContain("renewed with new expiry");
+	});
+});
+
+describe("renew command — JSON output", () => {
+	useTestDir("renew-json");
+
+	it("outputs structured JSON", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		const owner = await createAgent({ domain: "o.local", algorithm: "ES256" });
+		saveAgent(agent);
+		saveOwner(owner);
+
+		const d = await delegate({
+			agent: agent.did,
+			owner: owner.did,
+			ownerKeyPair: owner.keyPair,
+			scopes: ["read", "write"],
+		});
+		saveDelegation(d);
+
+		const { renewCommand } = await import("./renew.js");
+		await renewCommand({ until: "2099-01-01T00:00:00Z", json: true });
+
+		const logs = collectLogs();
+		const jsonLine = logs.split("\n").find((l: string) => l.startsWith("{"));
+		expect(jsonLine).toBeDefined();
+
+		const parsed = JSON.parse(jsonLine!);
+		expect(parsed.renewed).toBe(true);
+		expect(parsed.agent).toBe(agent.did);
+		expect(parsed.owner).toBe(owner.did);
+		expect(parsed.scopes).toEqual(["read", "write"]);
+		expect(parsed.validUntil).toBe("2099-01-01T00:00:00Z");
+		expect(parsed.token).toBeTruthy();
+	});
+});
+
+describe("renew command — verify renewed token", () => {
+	useTestDir("renew-verify");
+
+	it("renewed token is cryptographically valid", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		const owner = await createAgent({ domain: "o.local", algorithm: "ES256" });
+		saveAgent(agent);
+		saveOwner(owner);
+
+		const d = await delegate({
+			agent: agent.did,
+			owner: owner.did,
+			ownerKeyPair: owner.keyPair,
+			scopes: ["read"],
+		});
+		saveDelegation(d);
+
+		const { renewCommand } = await import("./renew.js");
+		await renewCommand({ until: "2099-12-31T00:00:00Z" });
+
+		const renewed = loadDelegationFile();
+
+		const { verifyCommand } = await import("./verify.js");
+		await verifyCommand(renewed.token, { json: true });
+
+		const logs = collectLogs();
+		const jsonLine = logs.split("\n").find((l: string) => l.startsWith("{"));
+		const parsed = JSON.parse(jsonLine!);
+		expect(parsed.valid).toBe(true);
+		expect(parsed.validUntil).toBe("2099-12-31T00:00:00Z");
+	});
+});

--- a/src/commands/renew.test.ts
+++ b/src/commands/renew.test.ts
@@ -94,7 +94,7 @@ describe("renew command — happy path", () => {
 			ownerKeyPair: owner.keyPair,
 			scopes: ["payments:read", "invoices:create"],
 			constraints: { maxTransactionValue: 5000 },
-			validUntil: "2025-01-01T00:00:00Z",
+			validUntil: "2050-01-01T00:00:00Z",
 		});
 		saveDelegation(original);
 

--- a/src/commands/renew.ts
+++ b/src/commands/renew.ts
@@ -1,0 +1,82 @@
+import { delegate } from "credat";
+import pc from "picocolors";
+import {
+	delegationExists,
+	header,
+	label,
+	loadDelegationFile,
+	loadOwnerFile,
+	ownerExists,
+	saveDelegation,
+	success,
+	truncate,
+} from "../utils.js";
+
+interface RenewOptions {
+	until: string;
+	json?: boolean;
+}
+
+export async function renewCommand(options: RenewOptions): Promise<void> {
+	// 1. Load existing delegation
+	if (!delegationExists()) {
+		throw new Error(
+			`No delegation found. Run ${pc.bold("credat delegate")} first.`,
+		);
+	}
+	if (!ownerExists()) {
+		throw new Error(`No owner found. Run ${pc.bold("credat delegate")} first.`);
+	}
+
+	const existing = loadDelegationFile();
+	const owner = loadOwnerFile();
+
+	// 2. Validate new expiry
+	if (Number.isNaN(Date.parse(options.until))) {
+		throw new Error("--until must be a valid ISO 8601 date");
+	}
+
+	const newExpiry = new Date(options.until);
+	if (newExpiry <= new Date()) {
+		throw new Error("--until must be in the future");
+	}
+
+	// 3. Re-issue with same params, new expiry
+	const newDelegation = await delegate({
+		agent: existing.claims.agent,
+		owner: existing.claims.owner,
+		ownerKeyPair: owner.keyPair,
+		scopes: existing.claims.scopes,
+		constraints: existing.claims.constraints,
+		validUntil: options.until,
+	});
+
+	saveDelegation(newDelegation);
+
+	// 4. Output
+	if (options.json) {
+		console.log(
+			JSON.stringify({
+				renewed: true,
+				agent: existing.claims.agent,
+				owner: existing.claims.owner,
+				scopes: existing.claims.scopes,
+				constraints: existing.claims.constraints ?? null,
+				validUntil: options.until,
+				token: newDelegation.token,
+			}),
+		);
+		return;
+	}
+
+	header("Delegation Renewed");
+	label("Agent", pc.green(existing.claims.agent));
+	label("Owner", pc.cyan(existing.claims.owner));
+	label("Scopes", existing.claims.scopes.map((s) => pc.yellow(s)).join(", "));
+	label("New Expiry", pc.green(options.until));
+	console.log();
+	label("Token", pc.dim(truncate(newDelegation.token, 80)));
+	label("Saved to", pc.dim(".credat/delegation.json"));
+	console.log();
+	success("Delegation renewed with new expiry");
+}

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -1,0 +1,390 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	createAgent,
+	createStatusList,
+	delegate,
+	encodeStatusList,
+} from "credat";
+import { describe, expect, it } from "vitest";
+import { collectLogs, useTestDir } from "./test-utils.js";
+import {
+	credatDir,
+	loadAgentFile,
+	loadDelegationFile,
+	loadOwnerFile,
+	saveAgent,
+	saveDelegation,
+	saveOwner,
+} from "./utils.js";
+
+// ── Full workflow: init → delegate → verify → inspect → revoke ──
+
+describe("E2E: full delegation lifecycle", () => {
+	useTestDir("e2e-lifecycle");
+
+	it("init → delegate → verify → inspect → revoke", async () => {
+		// 1. Init — create agent identity
+		const { initCommand } = await import("./commands/init.js");
+		await initCommand({ domain: "agent.example", algorithm: "ES256" });
+
+		const agent = loadAgentFile();
+		expect(agent.did).toContain("did:web:agent.example");
+		expect(existsSync(join(credatDir(), "agent.json"))).toBe(true);
+
+		// 2. Delegate — issue credential with constraints
+		const { delegateCommand } = await import("./commands/delegate.js");
+		await delegateCommand({
+			scopes: "payments:read,invoices:create",
+			maxValue: "5000",
+			until: "2099-12-31T23:59:59Z",
+		});
+
+		const delegation = loadDelegationFile();
+		expect(delegation.token).toBeTruthy();
+		expect(delegation.claims.scopes).toEqual([
+			"payments:read",
+			"invoices:create",
+		]);
+		expect(existsSync(join(credatDir(), "owner.json"))).toBe(true);
+
+		// 3. Verify — cryptographic verification
+		const { verifyCommand } = await import("./commands/verify.js");
+		await verifyCommand(delegation.token);
+
+		let logs = collectLogs();
+		expect(logs).toContain("Valid delegation");
+		expect(logs).toContain(agent.did);
+
+		// 4. Inspect — decode without verification
+		const { inspectCommand } = await import("./commands/inspect.js");
+		inspectCommand(delegation.token);
+
+		logs = collectLogs();
+		expect(logs).toContain("ES256");
+		expect(logs).toContain("dc+sd-jwt");
+		expect(logs).toContain("AgentDelegationCredential");
+		expect(logs).toContain("payments:read");
+
+		// 5. Revoke — need a status list for this token
+		// The delegation above doesn't have a status list entry,
+		// so we revoke by explicit index
+		const list = createStatusList({
+			id: "default",
+			issuer: loadOwnerFile().did,
+			url: `${loadOwnerFile().did}/status/1`,
+		});
+		const slPath = join(credatDir(), "status-list.json");
+		writeFileSync(
+			slPath,
+			JSON.stringify({
+				id: list.id,
+				issuer: list.issuer,
+				url: `${list.issuer}/status/1`,
+				size: list.size,
+				encoded: encodeStatusList(list.bitstring),
+			}),
+		);
+
+		const { revokeCommand } = await import("./commands/revoke.js");
+		revokeCommand({ index: "0" });
+
+		logs = collectLogs();
+		expect(logs).toContain("revoked");
+	});
+});
+
+describe("E2E: delegation with status list entry → revoke from token", () => {
+	useTestDir("e2e-status-revoke");
+
+	it("delegate with statusList → inspect sees status → revoke extracts index", async () => {
+		// Setup identities
+		const agentId = await createAgent({
+			domain: "agent.local",
+			algorithm: "ES256",
+		});
+		const ownerId = await createAgent({
+			domain: "owner.local",
+			algorithm: "ES256",
+		});
+		saveAgent(agentId);
+		saveOwner(ownerId);
+
+		// Create status list file
+		const list = createStatusList({
+			id: "default",
+			issuer: ownerId.did,
+			url: `${ownerId.did}/status/1`,
+		});
+		const dir = credatDir();
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(
+			join(dir, "status-list.json"),
+			JSON.stringify({
+				id: list.id,
+				issuer: list.issuer,
+				url: `${list.issuer}/status/1`,
+				size: list.size,
+				encoded: encodeStatusList(list.bitstring),
+			}),
+		);
+
+		// Delegate with status list entry
+		const d = await delegate({
+			agent: agentId.did,
+			owner: ownerId.did,
+			ownerKeyPair: ownerId.keyPair,
+			scopes: ["admin:read"],
+			statusList: { url: `${ownerId.did}/status/1`, index: 42 },
+		});
+		saveDelegation(d);
+
+		// Inspect — should see status entry in payload
+		const { inspectCommand } = await import("./commands/inspect.js");
+		inspectCommand(d.token, { json: true });
+
+		let logs = collectLogs();
+		const inspectJson = JSON.parse(
+			logs.split("\n").find((l: string) => l.startsWith("{"))!,
+		);
+		expect(inspectJson.payload.status).toBeDefined();
+		expect(inspectJson.payload.status.status_list.idx).toBe(42);
+
+		// Revoke — should extract index 42 from token
+		const { revokeCommand } = await import("./commands/revoke.js");
+		revokeCommand();
+
+		logs = collectLogs();
+		expect(logs).toContain("revoked");
+		expect(logs).toContain("42");
+	});
+});
+
+// ── Constraint combinations ──
+
+describe("E2E: constraint combinations in delegate → verify → inspect", () => {
+	useTestDir("e2e-constraints");
+
+	it("maxValue + validUntil propagate through verify and inspect", async () => {
+		const agentId = await createAgent({
+			domain: "agent.local",
+			algorithm: "ES256",
+		});
+		const ownerId = await createAgent({
+			domain: "owner.local",
+			algorithm: "ES256",
+		});
+		saveAgent(agentId);
+		saveOwner(ownerId);
+
+		const { delegateCommand } = await import("./commands/delegate.js");
+		await delegateCommand({
+			scopes: "payments:write",
+			maxValue: "10000",
+			until: "2099-06-15T00:00:00Z",
+		});
+
+		const delegation = loadDelegationFile();
+
+		// Verify sees constraints
+		const { verifyCommand } = await import("./commands/verify.js");
+		await verifyCommand(delegation.token, { json: true });
+
+		let logs = collectLogs();
+		const verifyJson = JSON.parse(
+			logs.split("\n").find((l: string) => l.startsWith("{"))!,
+		);
+		expect(verifyJson.valid).toBe(true);
+		expect(verifyJson.scopes).toEqual(["payments:write"]);
+		expect(verifyJson.constraints.maxTransactionValue).toBe(10000);
+		expect(verifyJson.validUntil).toBe("2099-06-15T00:00:00Z");
+
+		// Inspect sees constraints in disclosures
+		const { inspectCommand } = await import("./commands/inspect.js");
+		inspectCommand(delegation.token, { json: true });
+
+		logs = collectLogs();
+		const inspectJson = JSON.parse(
+			logs
+				.split("\n")
+				.filter((l: string) => l.startsWith("{"))
+				.pop()!,
+		);
+		const constraintDisc = inspectJson.disclosures.find(
+			(d: { name: string }) => d.name === "constraints",
+		);
+		expect(constraintDisc).toBeDefined();
+		expect(constraintDisc.value.maxTransactionValue).toBe(10000);
+	});
+
+	it("EdDSA algorithm works across the full flow", async () => {
+		// Create both agent and owner with EdDSA
+		const agentId = await createAgent({
+			domain: "ed.local",
+			algorithm: "EdDSA",
+		});
+		const ownerId = await createAgent({
+			domain: "owner.local",
+			algorithm: "EdDSA",
+		});
+		saveAgent(agentId);
+		saveOwner(ownerId);
+
+		const d = await delegate({
+			agent: agentId.did,
+			owner: ownerId.did,
+			ownerKeyPair: ownerId.keyPair,
+			scopes: ["read"],
+		});
+		saveDelegation(d);
+
+		const { verifyCommand } = await import("./commands/verify.js");
+		await verifyCommand(d.token);
+
+		const logs = collectLogs();
+		expect(logs).toContain("Valid delegation");
+
+		// Inspect confirms EdDSA (alg comes from owner/issuer key)
+		const { inspectCommand } = await import("./commands/inspect.js");
+		inspectCommand(d.token, { json: true });
+
+		const allLogs = collectLogs();
+		const inspectJson = JSON.parse(
+			allLogs
+				.split("\n")
+				.filter((l: string) => l.startsWith("{"))
+				.pop()!,
+		);
+		expect(inspectJson.header.alg).toBe("EdDSA");
+	});
+});
+
+// ── Status command after each step ──
+
+describe("E2E: status reflects state at each stage", () => {
+	useTestDir("e2e-status");
+
+	it("shows progressive state: none → agent → agent+owner+delegation", async () => {
+		const { statusCommand } = await import("./commands/status.js");
+
+		// Stage 0: empty
+		statusCommand({ json: true });
+		let logs = collectLogs();
+		let status = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		expect(status.agent).toBeNull();
+		expect(status.owner).toBeNull();
+		expect(status.delegation).toBeNull();
+
+		// Stage 1: after init
+		const { initCommand } = await import("./commands/init.js");
+		await initCommand({ domain: "status.local", algorithm: "ES256" });
+
+		statusCommand({ json: true });
+		logs = collectLogs();
+		const jsonLines = logs.split("\n").filter((l: string) => l.startsWith("{"));
+		status = JSON.parse(jsonLines[jsonLines.length - 1]!);
+		expect(status.agent).not.toBeNull();
+		expect(status.agent.did).toContain("did:web:status.local");
+		expect(status.owner).toBeNull();
+		expect(status.delegation).toBeNull();
+
+		// Stage 2: after delegate
+		const { delegateCommand } = await import("./commands/delegate.js");
+		await delegateCommand({
+			scopes: "read",
+			until: "2099-12-31T00:00:00Z",
+		});
+
+		statusCommand({ json: true });
+		logs = collectLogs();
+		const allJsonLines = logs
+			.split("\n")
+			.filter((l: string) => l.startsWith("{"));
+		status = JSON.parse(allJsonLines[allJsonLines.length - 1]!);
+		expect(status.agent).not.toBeNull();
+		expect(status.owner).not.toBeNull();
+		expect(status.delegation).not.toBeNull();
+		expect(status.delegation.scopes).toEqual(["read"]);
+		expect(status.delegation.expired).toBe(false);
+	});
+});
+
+// ── Owner reuse ──
+
+describe("E2E: owner identity reuse", () => {
+	useTestDir("e2e-owner-reuse");
+
+	it("second delegate reuses existing owner", async () => {
+		const { initCommand } = await import("./commands/init.js");
+		await initCommand({ domain: "reuse.local", algorithm: "ES256" });
+
+		const { delegateCommand } = await import("./commands/delegate.js");
+		await delegateCommand({ scopes: "read" });
+
+		const owner1 = loadOwnerFile();
+
+		// Second delegation — should reuse same owner
+		await delegateCommand({ scopes: "write" });
+
+		const owner2 = loadOwnerFile();
+		expect(owner2.did).toBe(owner1.did);
+
+		// Verify the new delegation
+		const delegation = loadDelegationFile();
+		const { verifyCommand } = await import("./commands/verify.js");
+		await verifyCommand(delegation.token);
+
+		const logs = collectLogs();
+		expect(logs).toContain("Valid delegation");
+	});
+});
+
+// ── JSON output consistency ──
+
+describe("E2E: JSON output is parseable across all commands", () => {
+	useTestDir("e2e-json");
+
+	it("all --json outputs are valid JSON", async () => {
+		const agentId = await createAgent({
+			domain: "json.local",
+			algorithm: "ES256",
+		});
+		const ownerId = await createAgent({
+			domain: "owner.local",
+			algorithm: "ES256",
+		});
+		saveAgent(agentId);
+		saveOwner(ownerId);
+
+		const d = await delegate({
+			agent: agentId.did,
+			owner: ownerId.did,
+			ownerKeyPair: ownerId.keyPair,
+			scopes: ["read"],
+		});
+		saveDelegation(d);
+
+		// Status JSON
+		const { statusCommand } = await import("./commands/status.js");
+		statusCommand({ json: true });
+
+		// Verify JSON
+		const { verifyCommand } = await import("./commands/verify.js");
+		await verifyCommand(d.token, { json: true });
+
+		// Inspect JSON
+		const { inspectCommand } = await import("./commands/inspect.js");
+		inspectCommand(d.token, { json: true });
+
+		// All outputs should be parseable JSON
+		const logs = collectLogs();
+		const jsonLines = logs
+			.split("\n")
+			.filter((l: string) => l.startsWith("{"));
+		expect(jsonLines.length).toBeGreaterThanOrEqual(3);
+
+		for (const line of jsonLines) {
+			expect(() => JSON.parse(line)).not.toThrow();
+		}
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,12 @@ import { Command, Option } from "commander";
 import { VERSION } from "credat";
 import pc from "picocolors";
 import { banner } from "./banner.js";
+import { auditCommand } from "./commands/audit.js";
 import { delegateCommand } from "./commands/delegate.js";
 import { demoCommand } from "./commands/demo.js";
 import { initCommand } from "./commands/init.js";
 import { inspectCommand } from "./commands/inspect.js";
+import { renewCommand } from "./commands/renew.js";
 import { revokeCommand } from "./commands/revoke.js";
 import { statusCommand } from "./commands/status.js";
 import { verifyCommand } from "./commands/verify.js";
@@ -94,6 +96,24 @@ program
 			token: options.token,
 			statusList: options.statusList,
 			index: options.index,
+			json: program.opts().json,
+		});
+	});
+
+program
+	.command("audit [token]")
+	.description("Validate a delegation token against security best practices")
+	.action(async (token) => {
+		await auditCommand(token, { json: program.opts().json });
+	});
+
+program
+	.command("renew")
+	.description("Renew a delegation with a new expiry date")
+	.requiredOption("-u, --until <date>", "New expiration date (ISO 8601)")
+	.action(async (options) => {
+		await renewCommand({
+			until: options.until,
 			json: program.opts().json,
 		});
 	});


### PR DESCRIPTION
## Summary
- **`credat audit [token]`** (#8): Validates delegation tokens against security best practices — checks expiration (expired/far-future/missing), scope breadth (wildcards, too many), constraints (maxTransactionValue), revocation endpoint, and issuer/subject presence. Returns pass/warn/fail findings with summary counts.
- **`credat renew --until <date>`** (#9): Re-issues existing delegation with same scopes and constraints but new expiry. Validates date is future ISO 8601. Renewed token is cryptographically valid and saved to `.credat/delegation.json`.
- **E2E test suite** (`src/e2e.test.ts`): 7 integration tests covering the full delegation lifecycle across all commands.

## Test plan
- [x] 102 tests across 10 test files, all passing
- [x] **Audit** (16 tests): expiration checks (expired/far-future/ok/missing/validUntil), scope breadth (wildcard/narrow), constraints (present/absent), revocation (present/absent), issuer/subject, pretty output, delegation.json fallback, summary counts
- [x] **Renew** (8 tests): no delegation, no owner, invalid date, past date, happy path preserving scopes+constraints, pretty output, JSON output, renewed token is cryptographically valid (verify)
- [x] **E2E** (7 tests): full init→delegate→verify→inspect→revoke, status list revocation from token, constraint propagation (delegate→verify→inspect), EdDSA full flow, progressive status state, owner reuse, JSON parseable across all commands
- [x] Lint, typecheck, build all pass

Closes #8, closes #9