### PR TITLE
feat: add handshake, keys, completions, and --output flag

### DIFF
--- a/src/commands/completions.test.ts
+++ b/src/commands/completions.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { collectLogs, useTestDir } from "../test-utils.js";
+
+describe("completions command", () => {
+	useTestDir("completions");
+
+	it("generates bash completions", async () => {
+		const { completionsCommand } = await import("./completions.js");
+		completionsCommand("bash");
+
+		const logs = collectLogs();
+		expect(logs).toContain("_credat()");
+		expect(logs).toContain("complete -F _credat credat");
+		expect(logs).toContain("init");
+		expect(logs).toContain("delegate");
+		expect(logs).toContain("handshake");
+	});
+
+	it("generates zsh completions", async () => {
+		const { completionsCommand } = await import("./completions.js");
+		completionsCommand("zsh");
+
+		const logs = collectLogs();
+		expect(logs).toContain("#compdef credat");
+		expect(logs).toContain("_credat");
+		expect(logs).toContain("init:Create an agent identity");
+	});
+
+	it("generates fish completions", async () => {
+		const { completionsCommand } = await import("./completions.js");
+		completionsCommand("fish");
+
+		const logs = collectLogs();
+		expect(logs).toContain("complete -c credat");
+		expect(logs).toContain("__fish_use_subcommand");
+		expect(logs).toContain("init");
+	});
+
+	it("errors on unsupported shell", async () => {
+		const { completionsCommand } = await import("./completions.js");
+		expect(() => completionsCommand("powershell")).toThrow("Unsupported shell");
+	});
+});

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -1,0 +1,208 @@
+import pc from "picocolors";
+import { success } from "../utils.js";
+
+const COMMANDS = [
+	"init",
+	"delegate",
+	"verify",
+	"inspect",
+	"revoke",
+	"audit",
+	"renew",
+	"handshake",
+	"keys",
+	"status",
+	"demo",
+	"completions",
+];
+
+function bashCompletion(): string {
+	return `# credat bash completion
+_credat() {
+  local cur prev commands
+  COMPREPLY=()
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+  prev="\${COMP_WORDS[COMP_CWORD-1]}"
+  commands="${COMMANDS.join(" ")}"
+
+  case "\${prev}" in
+    credat)
+      COMPREPLY=( $(compgen -W "\${commands}" -- "\${cur}") )
+      return 0
+      ;;
+    init)
+      COMPREPLY=( $(compgen -W "--domain --path --algorithm --force --output" -- "\${cur}") )
+      return 0
+      ;;
+    delegate)
+      COMPREPLY=( $(compgen -W "--agent --scopes --max-value --until --output --json" -- "\${cur}") )
+      return 0
+      ;;
+    verify|inspect|audit)
+      COMPREPLY=( $(compgen -W "--json --file" -- "\${cur}") )
+      return 0
+      ;;
+    revoke)
+      COMPREPLY=( $(compgen -W "--token --status-list --index --json" -- "\${cur}") )
+      return 0
+      ;;
+    renew)
+      COMPREPLY=( $(compgen -W "--until --json" -- "\${cur}") )
+      return 0
+      ;;
+    handshake)
+      COMPREPLY=( $(compgen -W "challenge present verify demo" -- "\${cur}") )
+      return 0
+      ;;
+    keys)
+      COMPREPLY=( $(compgen -W "export import list" -- "\${cur}") )
+      return 0
+      ;;
+    completions)
+      COMPREPLY=( $(compgen -W "bash zsh fish" -- "\${cur}") )
+      return 0
+      ;;
+    --algorithm)
+      COMPREPLY=( $(compgen -W "ES256 EdDSA" -- "\${cur}") )
+      return 0
+      ;;
+  esac
+}
+complete -F _credat credat`;
+}
+
+function zshCompletion(): string {
+	return `#compdef credat
+
+_credat() {
+  local -a commands
+  commands=(
+    'init:Create an agent identity with did:web'
+    'delegate:Issue a delegation credential to an agent'
+    'verify:Verify a delegation token'
+    'inspect:Decode and inspect a delegation token'
+    'revoke:Revoke a delegation credential'
+    'audit:Validate token against security best practices'
+    'renew:Renew a delegation with a new expiry'
+    'handshake:Challenge/response trust verification'
+    'keys:Import, export, and list key pairs'
+    'status:Show current .credat/ state'
+    'demo:Run a full interactive trust flow demo'
+    'completions:Generate shell completion scripts'
+  )
+
+  _arguments -C \\
+    '--json[Output as JSON]' \\
+    '--version[Show version]' \\
+    '--help[Show help]' \\
+    '1:command:->command' \\
+    '*::arg:->args'
+
+  case $state in
+    command)
+      _describe 'credat commands' commands
+      ;;
+    args)
+      case $words[1] in
+        init)
+          _arguments \\
+            '--domain[Domain for did:web]:domain:' \\
+            '--path[Optional sub-path]:path:' \\
+            '--algorithm[Signing algorithm]:algorithm:(ES256 EdDSA)' \\
+            '--force[Overwrite existing]' \\
+            '--output[Custom output file]:file:_files'
+          ;;
+        delegate)
+          _arguments \\
+            '--agent[Agent DID]:did:' \\
+            '--scopes[Comma-separated scopes]:scopes:' \\
+            '--max-value[Max transaction value]:number:' \\
+            '--until[Expiration date]:date:' \\
+            '--output[Custom output file]:file:_files' \\
+            '--json[Output as JSON]'
+          ;;
+        handshake)
+          _arguments '1:subcommand:(challenge present verify demo)'
+          ;;
+        keys)
+          _arguments '1:subcommand:(export import list)'
+          ;;
+        completions)
+          _arguments '1:shell:(bash zsh fish)'
+          ;;
+      esac
+      ;;
+  esac
+}
+
+_credat`;
+}
+
+function fishCompletion(): string {
+	return `# credat fish completion
+complete -c credat -e
+complete -c credat -n '__fish_use_subcommand' -a 'init' -d 'Create an agent identity'
+complete -c credat -n '__fish_use_subcommand' -a 'delegate' -d 'Issue a delegation credential'
+complete -c credat -n '__fish_use_subcommand' -a 'verify' -d 'Verify a delegation token'
+complete -c credat -n '__fish_use_subcommand' -a 'inspect' -d 'Decode and inspect a token'
+complete -c credat -n '__fish_use_subcommand' -a 'revoke' -d 'Revoke a delegation credential'
+complete -c credat -n '__fish_use_subcommand' -a 'audit' -d 'Validate token security'
+complete -c credat -n '__fish_use_subcommand' -a 'renew' -d 'Renew a delegation'
+complete -c credat -n '__fish_use_subcommand' -a 'handshake' -d 'Challenge/response flow'
+complete -c credat -n '__fish_use_subcommand' -a 'keys' -d 'Manage key pairs'
+complete -c credat -n '__fish_use_subcommand' -a 'status' -d 'Show .credat/ state'
+complete -c credat -n '__fish_use_subcommand' -a 'demo' -d 'Run interactive demo'
+complete -c credat -n '__fish_use_subcommand' -a 'completions' -d 'Generate completions'
+
+complete -c credat -n '__fish_seen_subcommand_from init' -l domain -d 'Domain for did:web' -r
+complete -c credat -n '__fish_seen_subcommand_from init' -l path -d 'Optional sub-path' -r
+complete -c credat -n '__fish_seen_subcommand_from init' -l algorithm -d 'Signing algorithm' -ra 'ES256 EdDSA'
+complete -c credat -n '__fish_seen_subcommand_from init' -l force -d 'Overwrite existing'
+complete -c credat -n '__fish_seen_subcommand_from init' -l output -d 'Custom output file' -rF
+
+complete -c credat -n '__fish_seen_subcommand_from delegate' -l agent -d 'Agent DID' -r
+complete -c credat -n '__fish_seen_subcommand_from delegate' -l scopes -d 'Comma-separated scopes' -r
+complete -c credat -n '__fish_seen_subcommand_from delegate' -l max-value -d 'Max transaction value' -r
+complete -c credat -n '__fish_seen_subcommand_from delegate' -l until -d 'Expiration date' -r
+complete -c credat -n '__fish_seen_subcommand_from delegate' -l output -d 'Custom output file' -rF
+
+complete -c credat -n '__fish_seen_subcommand_from handshake' -a 'challenge present verify demo'
+complete -c credat -n '__fish_seen_subcommand_from keys' -a 'export import list'
+complete -c credat -n '__fish_seen_subcommand_from completions' -a 'bash zsh fish'`;
+}
+
+export function completionsCommand(shell: string): void {
+	switch (shell) {
+		case "bash":
+			console.log(bashCompletion());
+			break;
+		case "zsh":
+			console.log(zshCompletion());
+			break;
+		case "fish":
+			console.log(fishCompletion());
+			break;
+		default:
+			throw new Error(`Unsupported shell: ${shell}. Use bash, zsh, or fish.`);
+	}
+}
+
+export function completionsInstallCommand(): void {
+	const shell = process.env.SHELL ?? "";
+	if (shell.includes("zsh")) {
+		console.log(pc.dim("  Run:"));
+		console.log(
+			`  ${pc.bold("credat completions zsh > ~/.zsh/completions/_credat")}`,
+		);
+	} else if (shell.includes("fish")) {
+		console.log(pc.dim("  Run:"));
+		console.log(
+			`  ${pc.bold("credat completions fish > ~/.config/fish/completions/credat.fish")}`,
+		);
+	} else {
+		console.log(pc.dim("  Run:"));
+		console.log(`  ${pc.bold("credat completions bash >> ~/.bashrc")}`);
+	}
+	console.log();
+	success("Follow the command above to install completions");
+}

--- a/src/commands/delegate.ts
+++ b/src/commands/delegate.ts
@@ -23,6 +23,7 @@ interface DelegateCommandOptions {
 	maxValue?: string;
 	until?: string;
 	json?: boolean;
+	output?: string;
 }
 
 export async function delegateCommand(
@@ -134,7 +135,7 @@ export async function delegateCommand(
 		validUntil,
 	});
 
-	saveDelegation(delegation);
+	const savedPath = saveDelegation(delegation, options.output);
 
 	if (options.json) {
 		console.log(
@@ -165,7 +166,7 @@ export async function delegateCommand(
 
 	console.log();
 	label("Token", pc.dim(truncate(delegation.token, 80)));
-	label("Saved to", pc.dim(".credat/delegation.json"));
+	label("Saved to", pc.dim(savedPath));
 	console.log();
 	success("Delegation credential created");
 }

--- a/src/commands/handshake.test.ts
+++ b/src/commands/handshake.test.ts
@@ -1,0 +1,163 @@
+import { createAgent, createChallenge, delegate } from "credat";
+import { describe, expect, it } from "vitest";
+import { collectLogs, useTestDir } from "../test-utils.js";
+import { saveAgent, saveDelegation, saveOwner } from "../utils.js";
+
+describe("handshake challenge", () => {
+	useTestDir("hs-challenge");
+
+	it("creates a challenge with --from DID", async () => {
+		const { handshakeChallengeCommand } = await import("./handshake.js");
+		handshakeChallengeCommand({ from: "did:web:service.local" });
+
+		const logs = collectLogs();
+		expect(logs).toContain("Challenge Created");
+		expect(logs).toContain("did:web:service.local");
+	});
+
+	it("JSON output is valid challenge message", async () => {
+		const { handshakeChallengeCommand } = await import("./handshake.js");
+		handshakeChallengeCommand({ from: "did:web:s.local", json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		expect(parsed.type).toBe("credat:challenge");
+		expect(parsed.from).toBe("did:web:s.local");
+		expect(parsed.nonce).toBeTruthy();
+		expect(parsed.timestamp).toBeTruthy();
+	});
+});
+
+describe("handshake present", () => {
+	useTestDir("hs-present");
+
+	it("creates presentation from challenge + local delegation", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		const owner = await createAgent({ domain: "o.local", algorithm: "ES256" });
+		saveAgent(agent);
+		saveOwner(owner);
+
+		const d = await delegate({
+			agent: agent.did,
+			owner: owner.did,
+			ownerKeyPair: owner.keyPair,
+			scopes: ["read"],
+		});
+		saveDelegation(d);
+
+		const challenge = createChallenge({ from: "did:web:service.local" });
+
+		const { handshakePresentCommand } = await import("./handshake.js");
+		await handshakePresentCommand({
+			challenge: JSON.stringify(challenge),
+			json: true,
+		});
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		expect(parsed.type).toBe("credat:presentation");
+		expect(parsed.from).toBe(agent.did);
+		expect(parsed.proof).toBeTruthy();
+	});
+
+	it("errors on invalid challenge JSON", async () => {
+		const { handshakePresentCommand } = await import("./handshake.js");
+		await expect(
+			handshakePresentCommand({ challenge: "not-json" }),
+		).rejects.toThrow("Invalid challenge JSON");
+	});
+
+	it("errors on wrong challenge type", async () => {
+		const { handshakePresentCommand } = await import("./handshake.js");
+		await expect(
+			handshakePresentCommand({
+				challenge: JSON.stringify({ type: "wrong" }),
+			}),
+		).rejects.toThrow("wrong type");
+	});
+
+	it("errors when no delegation exists", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		saveAgent(agent);
+
+		const challenge = createChallenge({ from: "did:web:s.local" });
+		const { handshakePresentCommand } = await import("./handshake.js");
+		await expect(
+			handshakePresentCommand({ challenge: JSON.stringify(challenge) }),
+		).rejects.toThrow("No delegation found");
+	});
+});
+
+describe("handshake verify", () => {
+	useTestDir("hs-verify");
+
+	it("verifies a valid presentation", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		const owner = await createAgent({ domain: "o.local", algorithm: "ES256" });
+		saveAgent(agent);
+		saveOwner(owner);
+
+		const d = await delegate({
+			agent: agent.did,
+			owner: owner.did,
+			ownerKeyPair: owner.keyPair,
+			scopes: ["payments:read"],
+		});
+		saveDelegation(d);
+
+		const challenge = createChallenge({ from: "did:web:service.local" });
+
+		// Present
+		const { handshakePresentCommand, handshakeVerifyCommand } = await import(
+			"./handshake.js"
+		);
+		await handshakePresentCommand({
+			challenge: JSON.stringify(challenge),
+			json: true,
+		});
+		const presentLogs = collectLogs();
+		const presentation = JSON.parse(
+			presentLogs.split("\n").find((l: string) => l.startsWith("{"))!,
+		);
+
+		// Verify
+		await handshakeVerifyCommand({
+			presentation: JSON.stringify(presentation),
+			challenge: JSON.stringify(challenge),
+			json: true,
+		});
+		const verifyLogs = collectLogs();
+		const jsonLines = verifyLogs
+			.split("\n")
+			.filter((l: string) => l.startsWith("{"));
+		const result = JSON.parse(jsonLines[jsonLines.length - 1]!);
+		expect(result.valid).toBe(true);
+		expect(result.agent).toBe(agent.did);
+		expect(result.scopes).toContain("payments:read");
+	});
+});
+
+describe("handshake demo", () => {
+	useTestDir("hs-demo");
+
+	it("runs full handshake flow", async () => {
+		const { handshakeDemoCommand } = await import("./handshake.js");
+		await handshakeDemoCommand({});
+
+		const logs = collectLogs();
+		expect(logs).toContain("Create service identity");
+		expect(logs).toContain("Agent presents credentials");
+		expect(logs).toContain("Service verifies presentation");
+		expect(logs).toContain("trust established");
+	});
+
+	it("JSON output for demo", async () => {
+		const { handshakeDemoCommand } = await import("./handshake.js");
+		await handshakeDemoCommand({ json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		expect(parsed.valid).toBe(true);
+		expect(parsed.scopes).toContain("payments:read");
+	});
+});

--- a/src/commands/handshake.ts
+++ b/src/commands/handshake.ts
@@ -1,0 +1,255 @@
+import {
+	type AgentIdentity,
+	createAgent,
+	createChallenge,
+	delegate,
+	presentCredentials,
+	verifyPresentation,
+} from "credat";
+import pc from "picocolors";
+import {
+	delegationExists,
+	fail,
+	header,
+	label,
+	loadAgentFile,
+	loadDelegationFile,
+	loadOwnerFile,
+	ownerExists,
+	step,
+	success,
+} from "../utils.js";
+
+interface ChallengeOptions {
+	from: string;
+	json?: boolean;
+}
+
+interface PresentOptions {
+	challenge: string;
+	json?: boolean;
+}
+
+interface VerifyOptions {
+	presentation: string;
+	challenge: string;
+	json?: boolean;
+}
+
+interface DemoOptions {
+	json?: boolean;
+}
+
+export function handshakeChallengeCommand(options: ChallengeOptions): void {
+	const challenge = createChallenge({ from: options.from });
+
+	if (options.json) {
+		console.log(JSON.stringify(challenge));
+		return;
+	}
+
+	header("Challenge Created");
+	label("From", pc.cyan(options.from));
+	label("Nonce", pc.dim(challenge.nonce));
+	label("Timestamp", challenge.timestamp);
+	console.log();
+	console.log(pc.dim("  Send this to the agent:"));
+	console.log(`  ${pc.yellow(JSON.stringify(challenge))}`);
+	console.log();
+}
+
+export async function handshakePresentCommand(
+	options: PresentOptions,
+): Promise<void> {
+	let challenge: ReturnType<typeof createChallenge>;
+	try {
+		challenge = JSON.parse(options.challenge);
+	} catch {
+		throw new Error("Invalid challenge JSON");
+	}
+
+	if (challenge.type !== "credat:challenge") {
+		throw new Error("Invalid challenge: wrong type field");
+	}
+
+	const agentFile = loadAgentFile();
+	const agent: AgentIdentity = {
+		...agentFile,
+		didDocument: agentFile.didDocument as AgentIdentity["didDocument"],
+	};
+	if (!delegationExists()) {
+		throw new Error(
+			`No delegation found. Run ${pc.bold("credat delegate")} first.`,
+		);
+	}
+	const delegation = loadDelegationFile();
+
+	const presentation = await presentCredentials({
+		challenge,
+		delegation: delegation.token,
+		agent,
+	});
+
+	if (options.json) {
+		console.log(JSON.stringify(presentation));
+		return;
+	}
+
+	header("Presentation Created");
+	label("From", pc.green(presentation.from));
+	label("Nonce", pc.dim(presentation.nonce));
+	console.log();
+	console.log(pc.dim("  Send this back to the challenger:"));
+	console.log(`  ${pc.yellow(JSON.stringify(presentation))}`);
+	console.log();
+}
+
+export async function handshakeVerifyCommand(
+	options: VerifyOptions,
+): Promise<void> {
+	let presentation: Awaited<ReturnType<typeof presentCredentials>>;
+	let challenge: ReturnType<typeof createChallenge>;
+
+	try {
+		presentation = JSON.parse(options.presentation);
+	} catch {
+		throw new Error("Invalid presentation JSON");
+	}
+	try {
+		challenge = JSON.parse(options.challenge);
+	} catch {
+		throw new Error("Invalid challenge JSON");
+	}
+
+	if (!ownerExists()) {
+		throw new Error(
+			`No owner key found. Run ${pc.bold("credat delegate")} first.`,
+		);
+	}
+
+	const owner = loadOwnerFile();
+	const agent = loadAgentFile();
+
+	const result = await verifyPresentation(presentation, {
+		challenge,
+		ownerPublicKey: owner.keyPair.publicKey,
+		agentPublicKey: agent.keyPair.publicKey,
+	});
+
+	if (options.json) {
+		console.log(
+			JSON.stringify({
+				valid: result.valid,
+				agent: result.agent ?? null,
+				owner: result.owner ?? null,
+				scopes: result.scopes ?? [],
+				errors: result.errors.map((e) => e.message),
+			}),
+		);
+		return;
+	}
+
+	header("Verification Result");
+	if (result.valid) {
+		success(pc.bold("Handshake verified"));
+	} else {
+		fail(pc.bold("Handshake failed"));
+	}
+	console.log();
+	label("Agent", result.agent ?? pc.dim("(unknown)"));
+	label("Owner", result.owner ?? pc.dim("(unknown)"));
+	const scopes = result.scopes ?? [];
+	if (scopes.length > 0) {
+		label("Scopes", scopes.map((s) => pc.yellow(s)).join(", "));
+	}
+	if (result.errors.length > 0) {
+		console.log();
+		for (const err of result.errors) {
+			console.log(`  ${pc.red("•")} ${err.message}`);
+		}
+	}
+	console.log();
+}
+
+export async function handshakeDemoCommand(
+	options: DemoOptions,
+): Promise<void> {
+	step(1, "Create service identity (challenger)");
+	const service = await createAgent({
+		domain: "service.local",
+		algorithm: "ES256",
+	});
+	if (!options.json) {
+		label("Service DID", pc.cyan(service.did));
+	}
+
+	step(2, "Create agent identity");
+	const agent = await createAgent({
+		domain: "agent.local",
+		algorithm: "ES256",
+	});
+	if (!options.json) {
+		label("Agent DID", pc.green(agent.did));
+	}
+
+	step(3, "Owner delegates to agent");
+	const owner = await createAgent({
+		domain: "owner.local",
+		algorithm: "ES256",
+	});
+	const delegation = await delegate({
+		agent: agent.did,
+		owner: owner.did,
+		ownerKeyPair: owner.keyPair,
+		scopes: ["payments:read", "invoices:create"],
+	});
+	if (!options.json) {
+		label("Owner DID", pc.cyan(owner.did));
+		label("Scopes", pc.yellow("payments:read, invoices:create"));
+	}
+
+	step(4, "Service sends challenge");
+	const challenge = createChallenge({ from: service.did });
+	if (!options.json) {
+		label("Nonce", pc.dim(challenge.nonce));
+	}
+
+	step(5, "Agent presents credentials");
+	const presentation = await presentCredentials({
+		challenge,
+		delegation: delegation.token,
+		agent,
+	});
+	if (!options.json) {
+		label("Proof", pc.dim(`${presentation.proof.slice(0, 32)}...`));
+	}
+
+	step(6, "Service verifies presentation");
+	const result = await verifyPresentation(presentation, {
+		challenge,
+		ownerPublicKey: owner.keyPair.publicKey,
+		agentPublicKey: agent.keyPair.publicKey,
+	});
+
+	if (options.json) {
+		console.log(
+			JSON.stringify({
+				valid: result.valid,
+				agent: result.agent,
+				owner: result.owner,
+				scopes: result.scopes,
+			}),
+		);
+		return;
+	}
+
+	console.log();
+	if (result.valid) {
+		success(pc.bold("Handshake complete — trust established"));
+	} else {
+		fail(pc.bold("Handshake failed"));
+	}
+	label("Agent", result.agent ?? "(unknown)");
+	label("Scopes", (result.scopes ?? []).map((s) => pc.yellow(s)).join(", "));
+	console.log();
+}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -9,12 +9,13 @@ interface InitOptions {
 	path?: string;
 	algorithm?: "ES256" | "EdDSA";
 	force?: boolean;
+	output?: string;
 }
 
 export async function initCommand(options: InitOptions): Promise<void> {
-	const { domain, path, algorithm = "ES256", force } = options;
+	const { domain, path, algorithm = "ES256", force, output } = options;
 
-	const agentPath = join(credatDir(), "agent.json");
+	const agentPath = output ?? join(credatDir(), "agent.json");
 	if (existsSync(agentPath) && !force) {
 		console.error(
 			pc.red("  Agent identity already exists at .credat/agent.json"),
@@ -25,12 +26,12 @@ export async function initCommand(options: InitOptions): Promise<void> {
 
 	const agent = await createAgent({ domain, path, algorithm });
 
-	saveAgent(agent);
+	const savedPath = saveAgent(agent, output);
 
 	header("Agent Created");
 	label("DID", pc.green(agent.did));
 	label("Algorithm", algorithm);
-	label("Saved to", pc.dim(".credat/agent.json"));
+	label("Saved to", pc.dim(savedPath));
 
 	console.log();
 	console.log(pc.bold("  Host this DID Document at:"));

--- a/src/commands/keys.test.ts
+++ b/src/commands/keys.test.ts
@@ -1,0 +1,130 @@
+import { createAgent } from "credat";
+import { describe, expect, it } from "vitest";
+import { collectLogs, useTestDir } from "../test-utils.js";
+import { loadAgentFile, saveAgent, saveOwner } from "../utils.js";
+
+describe("keys export", () => {
+	useTestDir("keys-export");
+
+	it("exports agent keys in JWK format", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		saveAgent(agent);
+
+		const { keysExportCommand } = await import("./keys.js");
+		keysExportCommand({ as: "agent" });
+
+		const logs = collectLogs();
+		expect(logs).toContain("WARNING");
+		expect(logs).toContain("PRIVATE KEY");
+		// Output should be valid JSON
+		const jsonPart = logs
+			.split("\n")
+			.filter((l: string) => !l.includes("WARNING") && !l.includes("Store"))
+			.join("\n")
+			.trim();
+		const parsed = JSON.parse(jsonPart);
+		expect(parsed.algorithm).toBe("ES256");
+		expect(parsed.publicKey.kty).toBe("EC");
+		expect(parsed.privateKey.d).toBeTruthy();
+	});
+
+	it("exports owner keys with --json", async () => {
+		const owner = await createAgent({ domain: "o.local", algorithm: "ES256" });
+		saveOwner(owner);
+
+		const { keysExportCommand } = await import("./keys.js");
+		keysExportCommand({ as: "owner", json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		expect(parsed.type).toBe("owner");
+		expect(parsed.did).toBe(owner.did);
+		expect(parsed.keys.algorithm).toBe("ES256");
+	});
+});
+
+describe("keys import", () => {
+	useTestDir("keys-import");
+
+	it("roundtrips export → import for agent", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		saveAgent(agent);
+
+		const { keysExportCommand, keysImportCommand } = await import("./keys.js");
+
+		// Export
+		keysExportCommand({ as: "agent", json: true });
+		const logs = collectLogs();
+		const exported = JSON.parse(
+			logs.split("\n").find((l: string) => l.startsWith("{"))!,
+		);
+
+		// Import back
+		keysImportCommand(JSON.stringify(exported.keys), { as: "agent" });
+
+		// Verify keys are the same
+		const loaded = loadAgentFile();
+		expect(Buffer.from(loaded.keyPair.publicKey).toString("base64url")).toBe(
+			Buffer.from(agent.keyPair.publicKey).toString("base64url"),
+		);
+	});
+
+	it("rejects invalid JSON", async () => {
+		const { keysImportCommand } = await import("./keys.js");
+		expect(() => keysImportCommand("not json", { as: "agent" })).toThrow(
+			"could not parse JSON",
+		);
+	});
+
+	it("rejects missing fields", async () => {
+		const { keysImportCommand } = await import("./keys.js");
+		expect(() =>
+			keysImportCommand(JSON.stringify({ algorithm: "ES256" }), {
+				as: "agent",
+			}),
+		).toThrow("missing required fields");
+	});
+
+	it("rejects unsupported algorithm", async () => {
+		const { keysImportCommand } = await import("./keys.js");
+		expect(() =>
+			keysImportCommand(
+				JSON.stringify({
+					algorithm: "RS256",
+					publicKey: {},
+					privateKey: { d: "abc" },
+				}),
+				{ as: "agent" },
+			),
+		).toThrow("Unsupported algorithm");
+	});
+});
+
+describe("keys list", () => {
+	useTestDir("keys-list");
+
+	it("shows both agent and owner keys", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		const owner = await createAgent({ domain: "o.local", algorithm: "EdDSA" });
+		saveAgent(agent);
+		saveOwner(owner);
+
+		const { keysListCommand } = await import("./keys.js");
+		keysListCommand({ json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(logs.split("\n").find((l: string) => l.startsWith("{"))!);
+		expect(parsed.keys).toHaveLength(2);
+		expect(parsed.keys[0].type).toBe("agent");
+		expect(parsed.keys[1].type).toBe("owner");
+		expect(parsed.keys[0].publicKeyFingerprint).toBeTruthy();
+	});
+
+	it("shows message when no keys exist", async () => {
+		const { keysListCommand } = await import("./keys.js");
+		keysListCommand({});
+
+		const logs = collectLogs();
+		expect(logs).toContain("No keys found");
+	});
+});

--- a/src/commands/keys.test.ts
+++ b/src/commands/keys.test.ts
@@ -11,21 +11,26 @@ describe("keys export", () => {
 		saveAgent(agent);
 
 		const { keysExportCommand } = await import("./keys.js");
+		keysExportCommand({ as: "agent", json: true });
+
+		const logs = collectLogs();
+		const parsed = JSON.parse(
+			logs.split("\n").find((l: string) => l.startsWith("{"))!,
+		);
+		expect(parsed.keys.algorithm).toBe("ES256");
+		expect(parsed.keys.publicKey.kty).toBe("EC");
+		expect(parsed.keys.privateKey.d).toBeTruthy();
+	});
+
+	it("pretty output warns about private key sensitivity", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		saveAgent(agent);
+
+		const { keysExportCommand } = await import("./keys.js");
 		keysExportCommand({ as: "agent" });
 
 		const logs = collectLogs();
-		expect(logs).toContain("WARNING");
 		expect(logs).toContain("PRIVATE KEY");
-		// Output should be valid JSON
-		const jsonPart = logs
-			.split("\n")
-			.filter((l: string) => !l.includes("WARNING") && !l.includes("Store"))
-			.join("\n")
-			.trim();
-		const parsed = JSON.parse(jsonPart);
-		expect(parsed.algorithm).toBe("ES256");
-		expect(parsed.publicKey.kty).toBe("EC");
-		expect(parsed.privateKey.d).toBeTruthy();
 	});
 
 	it("exports owner keys with --json", async () => {

--- a/src/commands/keys.ts
+++ b/src/commands/keys.ts
@@ -1,0 +1,218 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+	type Algorithm,
+	type JsonWebKey,
+	jwkToPublicKey,
+	publicKeyToJwk,
+} from "credat";
+import pc from "picocolors";
+import {
+	credatDir,
+	header,
+	label,
+	loadAgentFile,
+	loadOwnerFile,
+	ownerExists,
+	serializeKeyPair,
+	success,
+	writeSecureFile,
+} from "../utils.js";
+
+interface ExportOptions {
+	as: "agent" | "owner";
+	json?: boolean;
+}
+
+interface ImportOptions {
+	as: "agent" | "owner";
+	json?: boolean;
+}
+
+interface ListOptions {
+	json?: boolean;
+}
+
+interface JwkKeyPair {
+	algorithm: string;
+	publicKey: JsonWebKey;
+	privateKey: JsonWebKey & { d?: string };
+}
+
+export function keysExportCommand(options: ExportOptions): void {
+	const identity = options.as === "agent" ? loadAgentFile() : loadOwnerFile();
+
+	const pubJwk = publicKeyToJwk(
+		identity.keyPair.publicKey,
+		identity.keyPair.algorithm,
+	);
+
+	// For private key export, we serialize as base64url (JWK private export
+	// requires curve-specific handling — we use a wrapped format)
+	const exported: JwkKeyPair = {
+		algorithm: identity.keyPair.algorithm,
+		publicKey: pubJwk,
+		privateKey: {
+			...pubJwk,
+			d: Buffer.from(identity.keyPair.privateKey).toString("base64url"),
+		},
+	};
+
+	if (options.json) {
+		console.log(
+			JSON.stringify({ type: options.as, did: identity.did, keys: exported }),
+		);
+		return;
+	}
+
+	console.log(
+		pc.yellow("\n  ⚠ WARNING: This output contains PRIVATE KEY material."),
+	);
+	console.log(pc.yellow("  Store it securely and never share it.\n"));
+	console.log(JSON.stringify(exported, null, 2));
+}
+
+export function keysImportCommand(
+	jwkData: string,
+	options: ImportOptions,
+): void {
+	let parsed: JwkKeyPair;
+	try {
+		parsed = JSON.parse(jwkData) as JwkKeyPair;
+	} catch {
+		throw new Error("Invalid JWK: could not parse JSON");
+	}
+
+	if (!parsed.algorithm || !parsed.publicKey || !parsed.privateKey) {
+		throw new Error(
+			"Invalid JWK: missing required fields (algorithm, publicKey, privateKey)",
+		);
+	}
+
+	const algorithm = parsed.algorithm as Algorithm;
+	if (algorithm !== "ES256" && algorithm !== "EdDSA") {
+		throw new Error(`Unsupported algorithm: ${parsed.algorithm}`);
+	}
+
+	const publicKey = jwkToPublicKey(parsed.publicKey);
+	const dField = (parsed.privateKey as { d?: string }).d;
+	if (!dField) {
+		throw new Error("Invalid JWK: private key missing 'd' field");
+	}
+	const privateKey = new Uint8Array(Buffer.from(dField, "base64url"));
+
+	const serialized = serializeKeyPair({ algorithm, publicKey, privateKey });
+	const dir = credatDir();
+
+	if (options.as === "agent") {
+		const agentPath = join(dir, "agent.json");
+		if (existsSync(agentPath)) {
+			const existing = loadAgentFile();
+			const data = {
+				...existing,
+				keyPair: serialized,
+				algorithm,
+			};
+			writeSecureFile(agentPath, JSON.stringify(data, null, "\t"));
+		} else {
+			throw new Error(
+				`No agent file found. Run ${pc.bold("credat init")} first, then import keys.`,
+			);
+		}
+	} else {
+		const ownerPath = join(dir, "owner.json");
+		if (existsSync(ownerPath)) {
+			const existing = loadOwnerFile();
+			const data = {
+				did: existing.did,
+				keyPair: serialized,
+			};
+			writeSecureFile(ownerPath, JSON.stringify(data, null, "\t"));
+		} else {
+			throw new Error(
+				`No owner file found. Run ${pc.bold("credat delegate")} first, then import keys.`,
+			);
+		}
+	}
+
+	if (options.json) {
+		console.log(JSON.stringify({ imported: true, as: options.as, algorithm }));
+		return;
+	}
+
+	success(`${options.as} keys imported`);
+	label("Algorithm", algorithm);
+	console.log();
+}
+
+export function keysListCommand(options: ListOptions): void {
+	const agentPath = join(credatDir(), "agent.json");
+	const hasAgent = existsSync(agentPath);
+	const hasOwner = ownerExists();
+
+	interface KeyInfo {
+		type: string;
+		did: string;
+		algorithm: string;
+		publicKeyFingerprint: string;
+	}
+
+	const keys: KeyInfo[] = [];
+
+	if (hasAgent) {
+		const agent = loadAgentFile();
+		const jwk = publicKeyToJwk(
+			agent.keyPair.publicKey,
+			agent.keyPair.algorithm,
+		);
+		const fingerprint = Buffer.from(JSON.stringify(jwk))
+			.toString("base64url")
+			.slice(0, 16);
+		keys.push({
+			type: "agent",
+			did: agent.did,
+			algorithm: agent.keyPair.algorithm,
+			publicKeyFingerprint: fingerprint,
+		});
+	}
+
+	if (hasOwner) {
+		const owner = loadOwnerFile();
+		const jwk = publicKeyToJwk(
+			owner.keyPair.publicKey,
+			owner.keyPair.algorithm,
+		);
+		const fingerprint = Buffer.from(JSON.stringify(jwk))
+			.toString("base64url")
+			.slice(0, 16);
+		keys.push({
+			type: "owner",
+			did: owner.did,
+			algorithm: owner.keyPair.algorithm,
+			publicKeyFingerprint: fingerprint,
+		});
+	}
+
+	if (options.json) {
+		console.log(JSON.stringify({ keys }));
+		return;
+	}
+
+	if (keys.length === 0) {
+		console.log(
+			pc.dim(
+				`  No keys found. Run ${pc.bold("credat init")} to create an agent.`,
+			),
+		);
+		return;
+	}
+
+	header("Keys");
+	for (const k of keys) {
+		label("Type", k.type === "agent" ? pc.green(k.type) : pc.cyan(k.type));
+		label("DID", k.did);
+		label("Algorithm", k.algorithm);
+		label("Fingerprint", pc.dim(k.publicKeyFingerprint));
+		console.log();
+	}
+}

--- a/src/commands/output-flag.test.ts
+++ b/src/commands/output-flag.test.ts
@@ -1,0 +1,68 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { createAgent, delegate } from "credat";
+import { describe, expect, it } from "vitest";
+import { collectLogs, useTestDir } from "../test-utils.js";
+import { saveAgent, saveOwner } from "../utils.js";
+
+describe("--output flag on init", () => {
+	useTestDir("output-init");
+
+	it("saves agent to custom path", async () => {
+		const { initCommand } = await import("./init.js");
+		const customPath = join(process.cwd(), "custom", "my-agent.json");
+
+		await initCommand({
+			domain: "test.local",
+			algorithm: "ES256",
+			output: customPath,
+		});
+
+		expect(existsSync(customPath)).toBe(true);
+		const data = JSON.parse(readFileSync(customPath, "utf-8"));
+		expect(data.did).toContain("did:web:test.local");
+
+		// Check permissions (0o600)
+		const stats = statSync(customPath);
+		expect(stats.mode & 0o777).toBe(0o600);
+
+		const logs = collectLogs();
+		expect(logs).toContain(customPath);
+	});
+
+	it("default behavior unchanged when no --output", async () => {
+		const { initCommand } = await import("./init.js");
+		await initCommand({ domain: "default.local", algorithm: "ES256" });
+
+		expect(existsSync(join(process.cwd(), ".credat", "agent.json"))).toBe(
+			true,
+		);
+	});
+});
+
+describe("--output flag on delegate", () => {
+	useTestDir("output-delegate");
+
+	it("saves delegation to custom path", async () => {
+		const agent = await createAgent({ domain: "a.local", algorithm: "ES256" });
+		saveAgent(agent);
+
+		const { delegateCommand } = await import("./delegate.js");
+		const customPath = join(process.cwd(), "out", "deleg.json");
+
+		await delegateCommand({
+			scopes: "read",
+			output: customPath,
+		});
+
+		expect(existsSync(customPath)).toBe(true);
+		const data = JSON.parse(readFileSync(customPath, "utf-8"));
+		expect(data.token).toBeTruthy();
+
+		const stats = statSync(customPath);
+		expect(stats.mode & 0o777).toBe(0o600);
+
+		const logs = collectLogs();
+		expect(logs).toContain(customPath);
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,25 @@ import { VERSION } from "credat";
 import pc from "picocolors";
 import { banner } from "./banner.js";
 import { auditCommand } from "./commands/audit.js";
+import {
+	completionsCommand,
+	completionsInstallCommand,
+} from "./commands/completions.js";
 import { delegateCommand } from "./commands/delegate.js";
 import { demoCommand } from "./commands/demo.js";
+import {
+	handshakeChallengeCommand,
+	handshakeDemoCommand,
+	handshakePresentCommand,
+	handshakeVerifyCommand,
+} from "./commands/handshake.js";
 import { initCommand } from "./commands/init.js";
 import { inspectCommand } from "./commands/inspect.js";
+import {
+	keysExportCommand,
+	keysImportCommand,
+	keysListCommand,
+} from "./commands/keys.js";
 import { renewCommand } from "./commands/renew.js";
 import { revokeCommand } from "./commands/revoke.js";
 import { statusCommand } from "./commands/status.js";
@@ -35,12 +50,14 @@ program
 			.default("ES256"),
 	)
 	.option("-f, --force", "Overwrite existing agent identity")
+	.option("-o, --output <file>", "Write agent to custom file path")
 	.action(async (options) => {
 		await initCommand({
 			domain: options.domain,
 			path: options.path,
 			algorithm: options.algorithm,
 			force: options.force,
+			output: options.output,
 		});
 	});
 
@@ -54,6 +71,7 @@ program
 	)
 	.option("-m, --max-value <number>", "Maximum transaction value constraint")
 	.option("-u, --until <date>", "Expiration date (ISO 8601)")
+	.option("-o, --output <file>", "Write delegation to custom file path")
 	.action(async (options) => {
 		await delegateCommand({
 			agent: options.agent,
@@ -61,6 +79,7 @@ program
 			maxValue: options.maxValue,
 			until: options.until,
 			json: program.opts().json,
+			output: options.output,
 		});
 	});
 
@@ -117,6 +136,122 @@ program
 			json: program.opts().json,
 		});
 	});
+
+// ── Handshake subcommands ──
+
+const handshake = program
+	.command("handshake")
+	.description("Challenge/response trust verification flow");
+
+handshake
+	.command("challenge")
+	.description("Create a challenge for an agent")
+	.requiredOption("--from <did>", "Challenger DID")
+	.action((options) => {
+		handshakeChallengeCommand({
+			from: options.from,
+			json: program.opts().json,
+		});
+	});
+
+handshake
+	.command("present")
+	.description("Present credentials in response to a challenge")
+	.requiredOption("--challenge <json>", "Challenge JSON string")
+	.action(async (options) => {
+		await handshakePresentCommand({
+			challenge: options.challenge,
+			json: program.opts().json,
+		});
+	});
+
+handshake
+	.command("verify")
+	.description("Verify a presentation against a challenge")
+	.requiredOption("--presentation <json>", "Presentation JSON string")
+	.requiredOption("--challenge <json>", "Challenge JSON string")
+	.action(async (options) => {
+		await handshakeVerifyCommand({
+			presentation: options.presentation,
+			challenge: options.challenge,
+			json: program.opts().json,
+		});
+	});
+
+handshake
+	.command("demo")
+	.description("Run a full handshake demo between two local agents")
+	.action(async () => {
+		await handshakeDemoCommand({ json: program.opts().json });
+	});
+
+// ── Keys subcommands ──
+
+const keys = program
+	.command("keys")
+	.description("Import, export, and list key pairs");
+
+keys
+	.command("export")
+	.description("Export key pair in JWK format")
+	.addOption(
+		new Option("--as <type>", "Key type to export")
+			.choices(["agent", "owner"])
+			.default("agent"),
+	)
+	.action((options) => {
+		keysExportCommand({ as: options.as, json: program.opts().json });
+	});
+
+keys
+	.command("import <jwk-data>")
+	.description("Import key pair from JWK JSON")
+	.addOption(
+		new Option("--as <type>", "Import as agent or owner")
+			.choices(["agent", "owner"])
+			.default("agent"),
+	)
+	.action((jwkData, options) => {
+		keysImportCommand(jwkData, {
+			as: options.as,
+			json: program.opts().json,
+		});
+	});
+
+keys
+	.command("list")
+	.description("List current key fingerprints")
+	.action(() => {
+		keysListCommand({ json: program.opts().json });
+	});
+
+// ── Completions ──
+
+const completions = program
+	.command("completions")
+	.description("Generate shell completion scripts");
+
+completions
+	.command("bash")
+	.description("Generate bash completions")
+	.action(() => completionsCommand("bash"));
+
+completions
+	.command("zsh")
+	.description("Generate zsh completions")
+	.action(() => completionsCommand("zsh"));
+
+completions
+	.command("fish")
+	.description("Generate fish completions")
+	.action(() => completionsCommand("fish"));
+
+completions
+	.command("install")
+	.description("Show install instructions for your shell")
+	.action(() => completionsInstallCommand());
+
+// ── Status & Demo ──
 
 program
 	.command("status")

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import {
 	readFileSync,
 	writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
 	type Algorithm,
 	base64urlToUint8Array,
@@ -25,6 +25,15 @@ function ensureDir(): void {
 	if (!existsSync(dir)) {
 		mkdirSync(dir, { recursive: true, mode: 0o700 });
 	}
+}
+
+export function writeSecureFile(filePath: string, data: string): void {
+	const dir = dirname(filePath);
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true, mode: 0o700 });
+	}
+	writeFileSync(filePath, data);
+	chmodSync(filePath, 0o600);
 }
 
 // ── Serialization helpers for Uint8Array <-> base64url ──
@@ -62,13 +71,16 @@ export interface SerializedAgent {
 	didDocument: unknown;
 }
 
-export function saveAgent(agent: {
-	did: string;
-	domain: string;
-	path?: string;
-	keyPair: KeyPair;
-	didDocument: unknown;
-}): void {
+export function saveAgent(
+	agent: {
+		did: string;
+		domain: string;
+		path?: string;
+		keyPair: KeyPair;
+		didDocument: unknown;
+	},
+	outputPath?: string,
+): string {
 	ensureDir();
 	const data: SerializedAgent = {
 		did: agent.did,
@@ -78,9 +90,9 @@ export function saveAgent(agent: {
 		keyPair: serializeKeyPair(agent.keyPair),
 		didDocument: agent.didDocument,
 	};
-	const filePath = join(credatDir(), "agent.json");
-	writeFileSync(filePath, JSON.stringify(data, null, "\t"));
-	chmodSync(filePath, 0o600);
+	const filePath = outputPath ?? join(credatDir(), "agent.json");
+	writeSecureFile(filePath, JSON.stringify(data, null, "\t"));
+	return filePath;
 }
 
 export function loadAgentFile(): Omit<SerializedAgent, "keyPair"> & {
@@ -147,11 +159,14 @@ export interface DelegationFile {
 	};
 }
 
-export function saveDelegation(data: { token: string; claims: unknown }): void {
+export function saveDelegation(
+	data: { token: string; claims: unknown },
+	outputPath?: string,
+): string {
 	ensureDir();
-	const filePath = join(credatDir(), "delegation.json");
-	writeFileSync(filePath, JSON.stringify(data, null, "\t"));
-	chmodSync(filePath, 0o600);
+	const filePath = outputPath ?? join(credatDir(), "delegation.json");
+	writeSecureFile(filePath, JSON.stringify(data, null, "\t"));
+	return filePath;
 }
 
 export function delegationExists(): boolean {


### PR DESCRIPTION
## Summary
Closes all remaining open issues in a single PR:

- **`credat handshake`** (#4): `challenge`, `present`, `verify`, `demo` subcommands for interactive challenge/response trust verification using SDK's handshake APIs
- **`credat keys`** (#5): `export` (JWK format with private key warning), `import` (validates algorithm, fields, roundtrips), `list` (fingerprints, no private key material)
- **`credat completions`** (#6): `bash`, `zsh`, `fish` generation with full command/flag coverage + `install` subcommand with auto-detection
- **`--output <file>`** (#7): on `init` and `delegate`, writes to custom path with 0o600 permissions, auto-creates parent dirs

## Test plan
- [x] 126 tests across 14 test files, all passing
- [x] **Handshake** (9 tests): challenge creation, present with delegation, verify round-trip, invalid challenge JSON/type, missing delegation, demo flow, JSON output
- [x] **Keys** (8 tests): export agent/owner, roundtrip export→import, reject invalid JSON/fields/algorithm, list with both keys, empty list
- [x] **Completions** (4 tests): bash/zsh/fish output validation, unsupported shell error
- [x] **Output flag** (3 tests): init custom path with permissions, delegate custom path with permissions, default behavior preserved
- [x] Lint, typecheck, build all pass

Closes #4, closes #5, closes #6, closes #7