### PR TITLE
fix: migrate SDK dep from `credat` to `@credat/sdk`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Credat uses **Verifiable Credentials** and **Decentralized Identifiers** (DIDs) 
 
 ## Links
 
-- [credat SDK](https://github.com/credat/credat) — core library
+- [@credat/sdk](https://www.npmjs.com/package/@credat/sdk) — core library ([GitHub](https://github.com/credat/credat))
 - [DID specification](https://www.w3.org/TR/did-core/)
 - [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "0.1.0-alpha.1",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@credat/sdk": "^0.3.0-alpha.1",
 				"commander": "^13.1.0",
-				"credat": "^0.2.1-alpha.1",
 				"picocolors": "^1.1.1"
 			},
 			"bin": {
@@ -188,6 +188,27 @@
 			],
 			"engines": {
 				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@credat/sdk": {
+			"version": "0.3.0-alpha.1",
+			"resolved": "https://registry.npmjs.org/@credat/sdk/-/sdk-0.3.0-alpha.1.tgz",
+			"integrity": "sha512-116kcJT56qrrHUR6gstCnikMGG5k9KbO/lmEOvsVnxqdeCbfEBAmGmKfADN7f+Aj4OrGqTc4Rc2SFuEcb1EjNg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@noble/curves": "^2.0.1",
+				"@noble/hashes": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			},
+			"peerDependencies": {
+				"better-sqlite3": ">=11.0.0"
+			},
+			"peerDependenciesMeta": {
+				"better-sqlite3": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -1307,27 +1328,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^14.18.0 || >=16.10.0"
-			}
-		},
-		"node_modules/credat": {
-			"version": "0.2.1-alpha.1",
-			"resolved": "https://registry.npmjs.org/credat/-/credat-0.2.1-alpha.1.tgz",
-			"integrity": "sha512-wWDEn+IIJk7M6NfWgJTWw3p4gZb+ZYAoBgn3tYemdsg3pOBFlZXlL+rxG4GAqprtp8HmLAY2U8yN4dZOkUAsXw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@noble/curves": "^2.0.1",
-				"@noble/hashes": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=22.0.0"
-			},
-			"peerDependencies": {
-				"better-sqlite3": ">=11.0.0"
-			},
-			"peerDependenciesMeta": {
-				"better-sqlite3": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"commander": "^13.1.0",
-		"credat": "^0.2.1-alpha.1",
+		"@credat/sdk": "^0.3.0-alpha.1",
 		"picocolors": "^1.1.1"
 	},
 	"devDependencies": {

--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -1,4 +1,4 @@
-import { createAgent, delegate } from "credat";
+import { createAgent, delegate } from "@credat/sdk";
 import { describe, expect, it } from "vitest";
 import { collectLogs, useTestDir } from "../test-utils.js";
 import { saveDelegation, saveOwner } from "../utils.js";

--- a/src/commands/delegate.test.ts
+++ b/src/commands/delegate.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { createAgent } from "credat";
+import { createAgent } from "@credat/sdk";
 import { describe, expect, it } from "vitest";
 import { ExitError, collectLogs, useTestDir } from "../test-utils.js";
 import { credatDir, saveAgent } from "../utils.js";

--- a/src/commands/delegate.ts
+++ b/src/commands/delegate.ts
@@ -3,7 +3,7 @@ import {
 	type DelegationConstraints,
 	delegate,
 	type KeyPair,
-} from "credat";
+} from "@credat/sdk";
 import pc from "picocolors";
 import {
 	header,

--- a/src/commands/demo.ts
+++ b/src/commands/demo.ts
@@ -6,7 +6,7 @@ import {
 	presentCredentials,
 	verifyDelegation,
 	verifyPresentation,
-} from "credat";
+} from "@credat/sdk";
 import pc from "picocolors";
 import { fail, label, sleep, step, success, truncate } from "../utils.js";
 

--- a/src/commands/handshake.test.ts
+++ b/src/commands/handshake.test.ts
@@ -1,4 +1,4 @@
-import { createAgent, createChallenge, delegate } from "credat";
+import { createAgent, createChallenge, delegate } from "@credat/sdk";
 import { describe, expect, it } from "vitest";
 import { collectLogs, useTestDir } from "../test-utils.js";
 import { saveAgent, saveDelegation, saveOwner } from "../utils.js";

--- a/src/commands/handshake.ts
+++ b/src/commands/handshake.ts
@@ -5,7 +5,7 @@ import {
 	delegate,
 	presentCredentials,
 	verifyPresentation,
-} from "credat";
+} from "@credat/sdk";
 import pc from "picocolors";
 import {
 	delegationExists,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { createAgent } from "credat";
+import { createAgent } from "@credat/sdk";
 import pc from "picocolors";
 import { credatDir, header, label, saveAgent, success } from "../utils.js";
 

--- a/src/commands/inspect.test.ts
+++ b/src/commands/inspect.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { createAgent, delegate } from "credat";
+import { createAgent, delegate } from "@credat/sdk";
 import { describe, expect, it } from "vitest";
 import { collectLogs, useTestDir } from "../test-utils.js";
 import { credatDir, saveDelegation } from "../utils.js";

--- a/src/commands/keys.test.ts
+++ b/src/commands/keys.test.ts
@@ -1,4 +1,4 @@
-import { createAgent } from "credat";
+import { createAgent } from "@credat/sdk";
 import { describe, expect, it } from "vitest";
 import { collectLogs, useTestDir } from "../test-utils.js";
 import { loadAgentFile, saveAgent, saveOwner } from "../utils.js";

--- a/src/commands/keys.ts
+++ b/src/commands/keys.ts
@@ -5,7 +5,7 @@ import {
 	type JsonWebKey,
 	jwkToPublicKey,
 	publicKeyToJwk,
-} from "credat";
+} from "@credat/sdk";
 import pc from "picocolors";
 import {
 	credatDir,

--- a/src/commands/output-flag.test.ts
+++ b/src/commands/output-flag.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { createAgent, delegate } from "credat";
+import { createAgent, delegate } from "@credat/sdk";
 import { describe, expect, it } from "vitest";
 import { collectLogs, useTestDir } from "../test-utils.js";
 import { saveAgent, saveOwner } from "../utils.js";

--- a/src/commands/renew.test.ts
+++ b/src/commands/renew.test.ts
@@ -1,4 +1,4 @@
-import { createAgent, delegate } from "credat";
+import { createAgent, delegate } from "@credat/sdk";
 import { describe, expect, it } from "vitest";
 import { collectLogs, useTestDir } from "../test-utils.js";
 import {

--- a/src/commands/renew.ts
+++ b/src/commands/renew.ts
@@ -1,4 +1,4 @@
-import { delegate } from "credat";
+import { delegate } from "@credat/sdk";
 import pc from "picocolors";
 import {
 	delegationExists,

--- a/src/commands/revoke.test.ts
+++ b/src/commands/revoke.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { createAgent, createStatusList, delegate, encodeStatusList } from "credat";
+import { createAgent, createStatusList, delegate, encodeStatusList } from "@credat/sdk";
 import { describe, expect, it } from "vitest";
 import { collectLogs, useTestDir } from "../test-utils.js";
 import { credatDir, saveDelegation, saveOwner } from "../utils.js";

--- a/src/commands/revoke.ts
+++ b/src/commands/revoke.ts
@@ -7,7 +7,7 @@ import {
 	isRevoked,
 	type StatusListData,
 	setRevocationStatus,
-} from "credat";
+} from "@credat/sdk";
 import pc from "picocolors";
 import {
 	credatDir,

--- a/src/commands/verify.test.ts
+++ b/src/commands/verify.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { createAgent, delegate } from "credat";
+import { createAgent, delegate } from "@credat/sdk";
 import { describe, expect, it } from "vitest";
 import { ExitError, collectLogs, useTestDir } from "../test-utils.js";
 import { credatDir, saveAgent, saveOwner } from "../utils.js";

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -1,4 +1,4 @@
-import { verifyDelegation } from "credat";
+import { verifyDelegation } from "@credat/sdk";
 import pc from "picocolors";
 import {
 	delegationExists,

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -5,7 +5,7 @@ import {
 	createStatusList,
 	delegate,
 	encodeStatusList,
-} from "credat";
+} from "@credat/sdk";
 import { describe, expect, it } from "vitest";
 import { collectLogs, useTestDir } from "./test-utils.js";
 import {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
+import { VERSION } from "@credat/sdk";
 import { Command, Option } from "commander";
-import { VERSION } from "credat";
 import pc from "picocolors";
 import { banner } from "./banner.js";
 import { auditCommand } from "./commands/audit.js";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ import {
 	base64urlToUint8Array,
 	type KeyPair,
 	uint8ArrayToBase64url,
-} from "credat";
+} from "@credat/sdk";
 import pc from "picocolors";
 
 const CREDAT_DIR = ".credat";


### PR DESCRIPTION
## Summary
- Updates dependency from `credat@^0.2.1-alpha.1` to `@credat/sdk@^0.3.0-alpha.1`
- Replaces all 20 `from "credat"` imports with `from "@credat/sdk"` across src/
- Updates README SDK link to point to the new npm package

## Test plan
- [x] 127 tests pass with new package
- [x] Lint, typecheck, build all pass
- [x] No stale `from "credat"` imports remain